### PR TITLE
Add type hints for infretis.core.core

### DIFF
--- a/infretis/classes/engines/factory.py
+++ b/infretis/classes/engines/factory.py
@@ -25,9 +25,9 @@ def create_engine(settings):
 
     """
     engine_map = {
-        "gromacs": {"cls": GromacsEngine},
-        "cp2k": {"cls": CP2KEngine},
-        "turtlemd": {"cls": TurtleMDEngine},
+        "gromacs": {"class": GromacsEngine},
+        "cp2k": {"class": CP2KEngine},
+        "turtlemd": {"class": TurtleMDEngine},
     }
 
     if settings["engine"]["class"].lower() not in engine_map:

--- a/infretis/classes/orderparameter.py
+++ b/infretis/classes/orderparameter.py
@@ -448,12 +448,12 @@ def create_orderparameter(settings):
 
     """
     order_map = {
-        "orderparameter": {"cls": OrderParameter},
-        "position": {"cls": Position},
-        "velocity": {"cls": Velocity},
-        "distance": {"cls": Distance},
-        "dihedral": {"cls": Dihedral},
-        "distancevel": {"cls": Distancevel},
+        "orderparameter": {"class": OrderParameter},
+        "position": {"class": Position},
+        "velocity": {"class": Velocity},
+        "distance": {"class": Distance},
+        "dihedral": {"class": Dihedral},
+        "distancevel": {"class": Distancevel},
     }
 
     if settings["orderparameter"]["class"].lower() not in order_map:
@@ -471,33 +471,6 @@ def create_orderparameter(settings):
         return None
     logger.info("Created main order parameter:\n%s", main_order)
     return main_order
-
-
-def order_factory(settings):
-    """Create order parameters according to the given settings.
-
-    This function is included as a convenient way of setting up and
-    selecting the order parameter.
-
-    Parameters
-    ----------
-    settings : dict
-        This defines how we set up and select the order parameter.
-
-    Returns
-    -------
-    out : object like :py:class:`.OrderParameter`
-        An object representing the order parameter.
-
-    """
-    factory_map = {
-        "orderparameter": {"cls": OrderParameter},
-        "position": {"cls": Position},
-        "velocity": {"cls": Velocity},
-        "distance": {"cls": Distance},
-        "distancevel": {"cls": Distancevel},
-    }
-    return generic_factory(settings, factory_map, name="orderparameter")
 
 
 def _verify_pair(index):

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -4,12 +4,17 @@ import inspect
 import logging
 import os
 import sys
+from typing import Any
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def generic_factory(settings, object_map, name="generic"):
+def generic_factory(
+    settings: dict[str, str],
+    object_map: dict[str, dict[str, Any]],
+    name: str = "generic",
+):
     """Create instances of classes based on settings.
 
     This method is intended as a semi-generic factory for creating
@@ -47,7 +52,7 @@ def generic_factory(settings, object_map, name="generic"):
             name,
         )
         return None
-    cls = object_map[klass]["cls"]
+    cls = object_map[klass]["class"]
     return initiate_instance(cls, settings)
 
 

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import errno
-import importlib
 import inspect
 import logging
 import os
 import sys
+from importlib import util
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -300,12 +300,13 @@ def import_from(module_path: str, function_name: str) -> Any:
         The thing we managed to import.
 
     """
+    msg = f"Could not import module: {module_path}"
     try:
         module_name = os.path.basename(module_path)
         module_name = os.path.splitext(module_name)[0]
-        spec = importlib.util.spec_from_file_location(module_name, module_path)
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        spec = util.spec_from_file_location(module_name, module_path)
+        module = util.module_from_spec(spec)  # type: ignore[arg-type]
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
         sys.modules[module_name] = module
         logger.debug("Imported module: %s", module)
         return getattr(module, function_name)

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -4,17 +4,21 @@ import inspect
 import logging
 import os
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    from infretis.classes.engines.enginebase import EngineBase
+    from infretis.classes.orderparameter import OrderParameter
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
 def generic_factory(
-    settings: dict[str, str],
+    settings: dict[str, Any],
     object_map: dict[str, dict[str, Any]],
     name: str = "generic",
-):
+) -> None | EngineBase | OrderParameter:
     """Create instances of classes based on settings.
 
     This method is intended as a semi-generic factory for creating
@@ -56,7 +60,9 @@ def generic_factory(
     return initiate_instance(cls, settings)
 
 
-def initiate_instance(klass, settings):
+def initiate_instance(
+    klass: type[Any], settings: dict[str, Any]
+) -> EngineBase | OrderParameter:
     """Initialise a class with optional arguments.
 
     Parameters

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -279,7 +279,7 @@ def create_external(settings, key, required_methods, key_settings=None):
     return initiate_instance(obj, settings)
 
 
-def import_from(module_path, function_name):
+def import_from(module_path: str, function_name: str) -> Any:
     """Import a method/class from a module.
 
     This method will dynamically import a specified method/object

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -124,9 +124,9 @@ def _pick_out_arg_kwargs(klass, settings):
         try:
             args.append(settings[arg])
             used.add(arg)
-        except KeyError:
+        except KeyError as exc:
             msg = f'Required argument "{arg}" for "{klass}" not found!'
-            raise ValueError(msg)
+            raise ValueError(msg) from exc
     for arg in info["kwargs"]:
         if arg == "self":
             continue

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -6,9 +6,10 @@ import logging
 import os
 import sys
 from importlib import util
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
     from inspect import Parameter
 
     from infretis.classes.engines.enginebase import EngineBase

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import errno
 import importlib
 import inspect
@@ -18,7 +20,7 @@ def generic_factory(
     settings: dict[str, Any],
     object_map: dict[str, dict[str, Any]],
     name: str = "generic",
-) -> None | EngineBase | OrderParameter:
+) -> EngineBase | OrderParameter | None:
     """Create instances of classes based on settings.
 
     This method is intended as a semi-generic factory for creating

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -9,6 +9,8 @@ from importlib import util
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover
+    from inspect import Parameter
+
     from infretis.classes.engines.enginebase import EngineBase
     from infretis.classes.orderparameter import OrderParameter
 
@@ -173,7 +175,7 @@ def inspect_function(function):
     return out
 
 
-def _arg_kind(arg):
+def _arg_kind(arg: Parameter) -> str | None:
     """Determine kind for a given argument.
 
     This method will help :py:func:`.inspect_function` to determine

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -100,7 +100,9 @@ def initiate_instance(
     return klass(*args, **kwargs)
 
 
-def _pick_out_arg_kwargs(klass, settings):
+def _pick_out_arg_kwargs(
+    klass: Any, settings: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
     """Pick out arguments for a class from settings.
 
     Parameters

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -316,7 +316,7 @@ def import_from(module_path, function_name):
     raise ValueError(msg)
 
 
-def make_dirs(dirname):
+def make_dirs(dirname: str) -> str:
     """Create directories for path simulations.
 
     This function will create a folder using a specified path.
@@ -336,6 +336,7 @@ def make_dirs(dirname):
         output.
 
     """
+    msg = f'Directory "{dirname}" was not created.'
     try:
         os.makedirs(dirname)
         msg = f'Created directory: "{dirname}"'

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 from importlib import util
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:  # pragma: no cover
     from inspect import Parameter
@@ -137,7 +137,7 @@ def _pick_out_arg_kwargs(klass, settings):
     return args, kwargs
 
 
-def inspect_function(function):
+def inspect_function(function: Callable) -> dict[str, list[Any]]:
     """Return arguments/kwargs of a given function.
 
     This method is intended for use where we are checking that we can
@@ -162,7 +162,12 @@ def inspect_function(function):
         * `keywords` : list of keyword arguments
 
     """
-    out = {"args": [], "kwargs": [], "varargs": [], "keywords": []}
+    out = {
+        "args": [],
+        "kwargs": [],
+        "varargs": [],
+        "keywords": [],
+    }  # type: dict[str, list[Any]]
     arguments = inspect.signature(function)  # pylint: disable=no-member
     for arg in arguments.parameters.values():
         kind = _arg_kind(arg)

--- a/test/core/test_core.py
+++ b/test/core/test_core.py
@@ -7,9 +7,7 @@ import pathlib
 import sys  # Used to make a local import
 from contextlib import contextmanager
 
-import numpy as np
 import pytest
-from numpy.random import RandomState
 
 from infretis.core.core import (
     _pick_out_arg_kwargs,
@@ -85,7 +83,7 @@ class ClassForTesting:
 
 def test_generic_factory(caplog):
     """Test that we can create classes with the generic factory."""
-    factory_map = {"my_new_class": {"cls": ClassForTesting}}
+    factory_map = {"my_new_class": {"class": ClassForTesting}}
 
     # Check that we can create the class:
     settings = {"class": "my_new_class"}


### PR DESCRIPTION
This PR will add type hints for the core.py file of infretis.core. Todo:

- [x] generic_factory
- [x] initiate_instance
- [x] _pick_out_arg_kwargs
- [x] inspect_function
- [x] _arg_kind
- [x] create_external
- [x] import_from
- [x] make_dirs