### PR TITLE
Split test

### DIFF
--- a/.github/workflows/heavy.yaml
+++ b/.github/workflows/heavy.yaml
@@ -3,7 +3,7 @@ name: Heavy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 5 * * 6'
+    - cron: '0 5 1,15 * *'
 
 jobs:
   test:

--- a/.github/workflows/heavy.yaml
+++ b/.github/workflows/heavy.yaml
@@ -1,10 +1,6 @@
-name: Test
+name: Heavy
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '30 5 * * 6'
@@ -12,7 +8,7 @@ on:
 jobs:
   test:
 
-    name: Tests
+    name: Heavy_tests
     strategy:
       fail-fast: false
       matrix:
@@ -47,4 +43,4 @@ jobs:
         run: poetry install
 
       - name: "Run pytest"
-        run: poetry run pytest test- m "not heavy"
+        run: poetry run pytest test- m "heavy"

--- a/.github/workflows/heavy.yaml
+++ b/.github/workflows/heavy.yaml
@@ -43,4 +43,4 @@ jobs:
         run: poetry install
 
       - name: "Run pytest"
-        run: poetry run pytest test- m "heavy"
+        run: poetry run pytest test -m "heavy"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,4 +47,4 @@ jobs:
         run: poetry install
 
       - name: "Run pytest"
-        run: poetry run pytest test- m "not heavy"
+        run: poetry run pytest test -m "not heavy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,14 @@ ignore_missing_imports = true
 module = "scipy.optimize.*"
 ignore_missing_imports = true
 
-
 [tool.poetry.scripts]
 infretisrun = "infretis.bin:infretisrun"
 infretisanalyze = "infretis.bin:infretisanalyze"
+
+[tool.pytest.ini_options]
+markers = [
+    "heavy: mark test as heavy.",
+]
 
 [build-system]
 requires = ["poetry-core"]

--- a/test/repex/test_repex.py
+++ b/test/repex/test_repex.py
@@ -3,6 +3,7 @@ from pathlib import PosixPath
 from infretis.classes.repex import REPEX_state
 
 def test_rgen_io(tmp_path: PosixPath) -> None:
+    """Test repex rgen and rgen spawn reproducability."""
     state = REPEX_state(
         {"current": {"size": 1},
          "dask": {"workers": 1},

--- a/test/simulations/test_run_infretis.py
+++ b/test/simulations/test_run_infretis.py
@@ -1,26 +1,21 @@
 """Test methods for doing TIS."""
-import os
-import tomli, tomli_w
-
-import numpy as np
-import shutil
 import filecmp
+import os
+import shutil
 from pathlib import PosixPath
 
-from infretis.classes.engines.engineparts import read_xyz_file
-from infretis.classes.engines.factory import create_engine
-from infretis.classes.engines.turtlemd import TurtleMDEngine
-from infretis.classes.orderparameter import create_orderparameters
-from infretis.classes.path import Path
-from infretis.core.tis import prepare_shooting_point, shoot, wire_fencing, compute_weight
+import pytest
+import tomli
+import tomli_w
 
 
 def change_toml_steps(inp, steps):
     with open(inp, mode="rb") as f:
         config = tomli.load(f)
-        config['simulation']['steps'] = steps
+        config["simulation"]["steps"] = steps
     with open(inp, "wb") as f:
         tomli_w.dump(config, f)
+
 
 def rm_restarted_from(inp):
     with open(inp, mode="rb") as f:
@@ -29,26 +24,28 @@ def rm_restarted_from(inp):
     with open(inp, "wb") as f:
         tomli_w.dump(config, f)
 
+
+@pytest.mark.heavy
 def test_run_airetis_wf(tmp_path: PosixPath) -> None:
     folder = tmp_path / "temp"
     folder.mkdir()
     basepath = os.path.dirname(__file__)
-    load_dir = os.path.join(basepath,
-                            "../../examples/turtlemd/double_well/load_copy")
-    toml_dir = os.path.join(basepath,
-                            "data/wf.toml")
+    load_dir = os.path.join(
+        basepath, "../../examples/turtlemd/double_well/load_copy"
+    )
+    toml_dir = os.path.join(basepath, "data/wf.toml")
     # copy files from template folder
-    shutil.copytree(load_dir, str(folder) + '/load')
-    shutil.copy(toml_dir, str(folder) + '/infretis.toml')
+    shutil.copytree(load_dir, str(folder) + "/load")
+    shutil.copy(toml_dir, str(folder) + "/infretis.toml")
     os.chdir(folder)
 
     success = os.system("infretisrun -i infretis.toml >| out.txt")
     assert success == 0
 
     # compare
-    items = ['infretis_data.txt', 'restart.toml']
+    items = ["infretis_data.txt", "restart.toml"]
     for item in items:
-        assert filecmp.cmp(f'./{item}', f'{basepath}/data/10steps_wf/{item}')
+        assert filecmp.cmp(f"./{item}", f"{basepath}/data/10steps_wf/{item}")
 
     change_toml_steps("restart.toml", 20)
     success = os.system("infretisrun -i restart.toml >> out.txt")
@@ -56,9 +53,9 @@ def test_run_airetis_wf(tmp_path: PosixPath) -> None:
     rm_restarted_from("restart.toml")
 
     # compare
-    items = ['infretis_data.txt', 'restart.toml']
+    items = ["infretis_data.txt", "restart.toml"]
     for item in items:
-        assert filecmp.cmp(f'./{item}', f'{basepath}/data/20steps_wf/{item}')
+        assert filecmp.cmp(f"./{item}", f"{basepath}/data/20steps_wf/{item}")
 
     change_toml_steps("restart.toml", 30)
     success = os.system("infretisrun -i restart.toml >> out.txt")
@@ -66,6 +63,6 @@ def test_run_airetis_wf(tmp_path: PosixPath) -> None:
     rm_restarted_from("restart.toml")
 
     # compare
-    items = ['infretis_data.txt', 'restart.toml']
+    items = ["infretis_data.txt", "restart.toml"]
     for item in items:
-        assert filecmp.cmp(f'./{item}', f'{basepath}/data/30steps_wf/{item}')
+        assert filecmp.cmp(f"./{item}", f"{basepath}/data/30steps_wf/{item}")


### PR DESCRIPTION
* split the unittest into light and heavy, such that the test pipeline only runs light. This reduces pytest time from 30s ->3s on my computer.
* added the pytest "heavy" tag
* added separate biweekly workflow for only the "heavy" simulations, @andersle will it run if i simply add a heavy.yaml in the github workflow folder?