### PR TITLE
update dask version

### DIFF
--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -66,7 +66,8 @@ def setup_dask(state):
     futures = as_completed(None, with_results=True)
 
     # setup individual worker logs
-    client.run(set_worker_logger)
+    for i in range(state.workers):
+        client.submit(set_worker_logger, i)
 
     return client, futures
 
@@ -164,7 +165,7 @@ def setup_logger(inp="sim.log"):
     logger.addHandler(fileh)
 
 
-def set_worker_logger():
+def set_worker_logger(i):
     """Set logger for each worker."""
     # for each worker
     pin = get_worker().name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ numpy = "^1.26.0"
 matplotlib = "^3.7.2"
 tomli = "^2.0.1"
 tomli-w = "^1.0.0"
-dask = "2023.3.0"
-distributed = "2023.3.0"
+dask = "^2023.3.0"
+distributed = "^2023.3.0"
 turtlemd = "^2023.3"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
solve issue https://github.com/infretis/infretis/issues/52 which was caused by https://dask.discourse.group/t/cannot-run-client-run-function-when-function-contains-get-worker-in-distributed-2023-3-2-1/1772 , which caused trouble when trying to set worker loggers. Going from client.run() -> for loop client.submit(), however, is not the best way to set logs for each worker, but it seems to work for now, and i cannot see any better solution.

Basically, client.run() does not work with get_workers(), so have to do loop client.submit().