### PR TITLE
Fix hardcoded default for MAXLENGTH different than other default values

### DIFF
--- a/infretis/classes/path.py
+++ b/infretis/classes/path.py
@@ -270,7 +270,7 @@ class Path:
 
     def empty_path(self, **kwargs) -> Path:
         """Return an empty path of same class as the current one."""
-        maxlen = kwargs.get("maxlen", 10000)
+        maxlen = kwargs.get("maxlen", DEFAULT_MAXLEN)
         time_origin = kwargs.get("time_origin", 0)
         return self.__class__(maxlen=maxlen, time_origin=time_origin)
 


### PR DESCRIPTION
This PR will fix a hardcoded 10 000 so that it is consistent with the other defaults for the same quantity.