### PR TITLE
Update toml

### DIFF
--- a/examples/cp2k/H2/infretis.toml
+++ b/examples/cp2k/H2/infretis.toml
@@ -37,11 +37,7 @@ index = [0, 1]
 periodic = true
 
 [output]
-backup = 'backup'
-data_dir = "./"
-order-file = 1
-energy-file = 1
-trajectory-file = 1
-screen = 1
-pattern = false
-delete_old = false
+data_dir = "./" # where to store infretis_data.txt
+screen = 1 # how often to print to sim.log
+pattern = false # how often we print info of which worker is in which ensemble at any time to pattern.txt
+delete_old = true # delete old accepted trajectories (e.g. .trr or .xyz files)

--- a/examples/gromacs/H2/infretis.toml
+++ b/examples/gromacs/H2/infretis.toml
@@ -30,10 +30,9 @@ mass = [1.008, 1.008] # then we also need to give masses
 class = 'gromacs'
 engine = 'gmx'
 timestep = 0.0002
-mdrun = 'gmx mdrun'
 gmx_format = 'g96'
 input_path = 'gromacs_input'
-gmx = 'gmx'
+gmx = 'gmx' # gromacs executable, may also be gmx_mpi, gmx_2023.3, etc.
 subcycles = 10
 
 [orderparameter]
@@ -42,11 +41,7 @@ index = [ 0, 1]
 periodic = true
 
 [output]
-backup = 'backup'
-data_dir = "./"
-order-file = 1
-energy-file = 1
-trajectory-file = -1
-screen = 1
-pattern = 1
-delete_old = true
+data_dir = "./" # where to store infretis_data.txt
+screen = 1 # how often to print to sim.log
+pattern = 1 # how often we print info of which worker is in which ensemble at any time to pattern.txt
+delete_old = true # delete old accepted trajectories (e.g. .trr or .xyz files)

--- a/examples/gromacs/puckering/step3_infretis/infretis.toml
+++ b/examples/gromacs/puckering/step3_infretis/infretis.toml
@@ -1,7 +1,9 @@
 # infretis config
 
 [dask]
-workers = 1
+workers = 1 # number of workers
+
+# each worker gets its own mdrun command
 wmdrun = ['gmx mdrun -ntomp 1 -ntmpi 1 -pinoffset 0 -pin on',
 	  'gmx mdrun -ntomp 1 -ntmpi 1 -pinoffset 1 -pin on',
 	  'gmx mdrun -ntomp 1 -ntmpi 1 -pinoffset 2 -pin on',
@@ -10,40 +12,39 @@ wmdrun = ['gmx mdrun -ntomp 1 -ntmpi 1 -pinoffset 0 -pin on',
 [simulation]
 interfaces = []
 
-steps = 20
+steps = 20 # number of infretis steps to perform
 seed = 0
-load_dir = 'load'
+load_dir = 'load' # directory to load paths
+
+# shooting moves in the various ensembles, which should have the same length as interfaces
+# sh: regular shooting, wf: wirefencing
 shooting_moves = ['sh', 'sh', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf']
 
 [simulation.tis_set]
-maxlength = 2000
-allowmaxlength = false
-zero_momentum = true # momentum true
-temperature = 300
-high_accept = true
-n_jumps = 2
-interface_cap = 70.0
+maxlength = 2000 # maximum path length (NB! this should never be reached )
+allowmaxlength = false  # do not allow paths to exceed maxlength when shooting from load paths
+zero_momentum = true # remove the center of mass motion when generating vels, done by gromacs by default
+temperature = 300 # velocities are generated at this temperature
+high_accept = true # we do want high-acceptance
+n_jumps = 2 # number of wirefencing jumps
+interface_cap = 70.0 # wirefencing interface cap
 
 [engine]
 class = 'gromacs'
 engine = 'gmx'
-timestep = 0.002
-mdrun = 'gmx'
-gmx_format = 'g96'
-input_path = '../gromacs_input'
-gmx = 'gmx'
-subcycles = 3
+timestep = 0.002 # md timestep
+gmx_format = 'g96' # only g96 is supported for gromacs
+input_path = '../gromacs_input' # path to topolofy files
+gmx = 'gmx' # gromacs executable, may also be gmx_mpi, gmx_2023.3, etc.
+subcycles = 3 # number of MD steps for each infretis step
 
 [orderparameter]
 class = 'puckering'
 index = []
-periodic = true
+periodic = true # correct atomic positions for periodic boundary conditions
 
 [output]
-backup = 'backup'
-data_dir = "./"
-order-file = 1
-energy-file = 1
-trajectory-file = -1
-screen = 1
-pattern = 1
+data_dir = "./" # where to store infretis_data.txt
+screen = 1 # how often to print to sim.log
+pattern = 1 # how often we print info of which worker is in which ensemble at any time to pattern.txt
+delete_old = false # keep all old accepted trajectories (e.g. .trr or .xyz files) for analysis, beware of storage

--- a/examples/lammps/H2/infretis.toml
+++ b/examples/lammps/H2/infretis.toml
@@ -37,11 +37,7 @@ index = [0, 1]
 periodic = true
 
 [output]
-backup = 'backup'
-data_dir = "./"
-order-file = 1
-energy-file = 1
-trajectory-file = 1
-screen = 1
-pattern = false
-delete_old = false
+data_dir = "./" # where to store infretis_data.txt
+screen = 1 # how often to print to sim.log
+pattern = false # how often we print info of which worker is in which ensemble at any time to pattern.txt
+delete_old = true # delete old accepted trajectories (e.g. .trr or .xyz files)

--- a/examples/turtlemd/H2/infretis.toml
+++ b/examples/turtlemd/H2/infretis.toml
@@ -62,11 +62,7 @@ index = [0, 1]
 periodic = true
 
 [output]
-backup = 'backup'
-data_dir = "./"
-order-file = -1
-energy-file = -1
-trajectory-file = -1
-screen = 1
-pattern = false
-delete_old = true
+data_dir = "./" # where to store infretis_data.txt
+screen = 1 # how often to print to sim.log
+pattern = false # how often we print info of which worker is in which ensemble at any time to pattern.txt
+delete_old = true # delete old accepted trajectories (e.g. .trr or .xyz files)

--- a/examples/turtlemd/double_well/infretis.toml
+++ b/examples/turtlemd/double_well/infretis.toml
@@ -63,11 +63,8 @@ periodic = false
 module = 'orderp.py'
 
 [output]
-backup = 'backup'
-data_dir = "./"
-order-file = -1
-energy-file = -1
-trajectory-file = -1
-screen = 1
-pattern = false
-delete_old = true
+[output]
+data_dir = "./" # where to store infretis_data.txt
+screen = 1 # how often to print to sim.log
+pattern = false # how often we print info of which worker is in which ensemble at any time to pattern.txt
+delete_old = true # delete old accepted trajectories (e.g. .trr or .xyz files)

--- a/examples/turtlemd/double_well/infretis.toml
+++ b/examples/turtlemd/double_well/infretis.toml
@@ -63,7 +63,6 @@ periodic = false
 module = 'orderp.py'
 
 [output]
-[output]
 data_dir = "./" # where to store infretis_data.txt
 screen = 1 # how often to print to sim.log
 pattern = false # how often we print info of which worker is in which ensemble at any time to pattern.txt

--- a/infretis/classes/engines/gromacs.py
+++ b/infretis/classes/engines/gromacs.py
@@ -79,10 +79,6 @@ class GromacsEngine(EngineBase):
 
     Attributes:
         gmx: The command for executing GROMACS.
-        mdrun: The command for executing GROMACS mdrun.
-        mdrun_c: The command for executing GROMACS mdrun when
-            continuing a simulation. This is derived from
-            the `mdrun` command.
         maxwarn: Setting for the GROMACS `grompp -maxwarn` option.
         gmx_format: This string selects the output format for GROMACS.
             Currently, only `"g96"` is supported.
@@ -93,7 +89,6 @@ class GromacsEngine(EngineBase):
     def __init__(
         self,
         gmx: str,
-        mdrun: str,
         input_path: str | Path,
         timestep: float,
         subcycles: int,
@@ -107,7 +102,6 @@ class GromacsEngine(EngineBase):
 
         Args:
             gmx: The GROMACS executable.
-            mdrun: The GROMACS mdrun executable.
             input_path: The absolute path to where the input files are stored.
             timestep: The time step used in the GROMACS MD simulation.
             subcycles: The number of steps each GROMACS MD run is composed of.
@@ -128,10 +122,6 @@ class GromacsEngine(EngineBase):
             raise ValueError(msg)
         # Define the GROMACS GMX command:
         self.gmx = gmx
-        # Define GROMACS GMX MDRUN commands:
-        self.mdrun = mdrun + " -s {} -deffnm {} -c {}"
-        # This is for continuation of a GROMACS simulation:
-        self.mdrun_c = mdrun + " -s {} -cpi {} -append -deffnm {} -c {}"
         self.ext_time = self.timestep * self.subcycles
         self.maxwarn = maxwarn
         # Define the energy terms, these are hard-coded, but

--- a/infretis/tools/generate_H2_loadpaths.py
+++ b/infretis/tools/generate_H2_loadpaths.py
@@ -53,7 +53,6 @@ def create_initial_paths():
     state.initiate_ensembles()
     engine: EngineBase = create_engine(config)
     engine.order_function = create_orderparameter(config)
-
     interfaces = np.array(config["simulation"]["interfaces"])
     # the initial configurations for each ensemble are given by the
     # interface location + (interface1 - interface0)/100
@@ -65,6 +64,10 @@ def create_initial_paths():
     # some engine setup
     exe_dir = Path("temporary_load")  # Path(engine.input_path) / "../load/"
     exe_dir = exe_dir.resolve()
+    engine.set_mdrun(
+        {"wmdrun": config["dask"]["wmdrun"][0], "exe_dir": exe_dir}
+    )
+
     exe_dir.mkdir()
     engine.exe_dir = exe_dir
     engine.rgen = np.random.default_rng()
@@ -77,10 +80,8 @@ def create_initial_paths():
         # some ensemble setup
         ensemble = state.ensembles[ens_name]
         ensemble["rgen"] = np.random.default_rng()
-        ensemble[
-            "allowmaxlength"
-        ] = True  # should be in simulation not tis_set
-        ensemble["maxlength"] = 2000  # should be in simulation not tis_set
+        ensemble["allowmaxlength"] = True
+        ensemble["maxlength"] = 2000
 
         # set up a temporary path to start from
         path = InfPath(maxlen=2000)

--- a/test/engines/test_velocity_functions.py
+++ b/test/engines/test_velocity_functions.py
@@ -54,9 +54,7 @@ def return_gromacs_engine():
     """Set up a gromacs engine for the H2 system."""
     gromacs_input_path = HERE / "../../examples/gromacs/H2/gromacs_input"
     # set`gmx = echo` here because __init__ calls `gmx` with subprocess
-    engine = GromacsEngine(
-        "echo", "foobar", gromacs_input_path.resolve(), 0, 0
-    )
+    engine = GromacsEngine("echo", gromacs_input_path.resolve(), 0, 0)
     engine.vel_settings = {
         "zero_momentum": True,
         "temperature": 300,


### PR DESCRIPTION
Remove unused keywords from the .toml files. This also lets us remove "mdrun" from the gromacs engine, because we now only use "wmdrun".