### PR TITLE
multiple engines (#89)

### DIFF
--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -26,7 +26,8 @@ def def_globals(config):
         config: Dictionary with engine settings.
     """
     global ENGINES
-    ENGINES = create_engines(config)
+    for i in range(config["dask"]["workers"]):
+        ENGINES[i] = create_engines(config)[config["engine"]["engine"]]
     create_orderparameters(ENGINES, config)
 
 
@@ -83,7 +84,7 @@ def run_md(md_items: dict[str, Any]) -> dict[str, Any]:
     # set mdrun, rng, clean_up
     for ens_num in md_items["ens_nums"]:
         pens = md_items["picked"][ens_num]
-        engine = ENGINES[pens["eng_name"]]
+        engine = ENGINES[md_items["pin"]]
         engine.set_mdrun(pens)
         if "rgen-eng" in pens:
             engine.rgen = pens["rgen-eng"]
@@ -91,7 +92,7 @@ def run_md(md_items: dict[str, Any]) -> dict[str, Any]:
 
     # perform the hw move:
     picked = md_items["picked"]
-    _, trials, status = select_shoot(picked)
+    _, trials, status = select_shoot(picked, engine)
 
     # Record data
     for trial, ens_num in zip(trials, picked.keys()):
@@ -256,7 +257,9 @@ def wirefence_weight_and_pick(
 
 
 def select_shoot(
-    picked: dict[int, Any], start_cond: tuple[str, ...] = ("L",)
+    picked: dict[int, Any],
+    engine: EngineBase,
+    start_cond: tuple[str, ...] = ("L",),
 ) -> tuple[bool, list[InfPath], str]:
     """Select shooting move and generate a new path.
 
@@ -281,7 +284,6 @@ def select_shoot(
 
     if len(picked) == 1:
         pens = next(iter(picked.values()))
-        engine = ENGINES[pens["eng_name"]]
         ens_set, path = (pens[i] for i in ["ens", "traj"])
         move = ens_set["mc_move"]
         logger.info(
@@ -294,7 +296,7 @@ def select_shoot(
         )
         new_paths = [new_path]
     else:
-        accept, new_paths, status = retis_swap_zero(picked)
+        accept, new_paths, status = retis_swap_zero(picked, engine)
 
     logger.info(f"Move was {accept} with status {status}\n")
     return accept, new_paths, status
@@ -773,6 +775,7 @@ def check_kick(
 
 def retis_swap_zero(
     picked: dict[int, Any],
+    engine: EngineBase,
 ) -> tuple[bool, list[InfPath], str]:
     """Perform the RETIS swapping for `[0^-] <-> [0^+]` swaps.
 
@@ -819,8 +822,8 @@ def retis_swap_zero(
     """
     ens_set0 = picked[-1]["ens"]
     ens_set1 = picked[0]["ens"]
-    engine0 = ENGINES[picked[-1]["eng_name"]]
-    engine1 = ENGINES[picked[0]["eng_name"]]
+    engine0 = engine
+    engine1 = engine
     path_old0 = picked[-1]["traj"]
     path_old1 = picked[0]["traj"]
     maxlen0 = ens_set0.get("maxlength", DEFAULT_MAXLEN)


### PR DESCRIPTION
The introduction of global engines sidesteps the issue of having to pickle unpickleable things.

However, with one global engine we seem to get issues with workers deleting certain files.

Therefore here I extend the global engine dict to create one engine per worker.