### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python"
         id: setuppy

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,7 +34,7 @@ jobs:
           poetry config virtualenvs.in-project true --local
 
       - name: "Cache the virtual environment"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./.venv
           key: venv-${{ steps.setuppy.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: "Set up Python"
         id: setuppy
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/heavy.yaml
+++ b/.github/workflows/heavy.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/heavy.yaml
+++ b/.github/workflows/heavy.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python"
         uses: actions/setup-python@v4

--- a/.github/workflows/heavy.yaml
+++ b/.github/workflows/heavy.yaml
@@ -34,7 +34,7 @@ jobs:
           poetry config virtualenvs.in-project true --local
 
       - name: "Cache the virtual environment"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./.venv
           key: venv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/lint-and-type.yaml
+++ b/.github/workflows/lint-and-type.yaml
@@ -36,7 +36,7 @@ jobs:
           poetry config virtualenvs.in-project true --local
 
       - name: "Cache the virtual environment"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./.venv
           key: venv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/lint-and-type.yaml
+++ b/.github/workflows/lint-and-type.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/lint-and-type.yaml
+++ b/.github/workflows/lint-and-type.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python"
         uses: actions/setup-python@v4

--- a/.github/workflows/pydocstyle.yaml
+++ b/.github/workflows/pydocstyle.yaml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python"
         uses: actions/setup-python@v4

--- a/.github/workflows/pydocstyle.yaml
+++ b/.github/workflows/pydocstyle.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python"
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python"
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
           poetry config virtualenvs.in-project true --local
 
       - name: "Cache the virtual environment"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./.venv
           key: venv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}


### PR DESCRIPTION
This PR updated versions of actions in workflows to:

* actions/cache@v4
* setup-python@v5
* actions/checkout@v4

This is to remove deprecations warnings when running the tests:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

(copied from https://github.com/andersle/infretis/actions/runs/8579062826).