### PR TITLE
Remove redundant infretis restart file

### DIFF
--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -366,18 +366,6 @@ class REPEX_state:
         ]
         return locks
 
-    # def save_rgen(self):
-    #     """Save numpy random generator state."""
-    #     save_loc = self.config["simulation"].get("save_loc", "./")
-    #     save_loc = os.path.join("./", save_loc, "infretis.restart")
-    #     # seed keeps track of number of children spawned
-    #     seed_state = {
-    #         "seed": self.rgen.bit_generator.seed_seq,
-    #         "state": self.rgen.bit_generator.state,
-    #     }
-    #     with open(save_loc, "wb") as outfile:
-    #         pickle.dump(seed_state, outfile)
-
     def set_rgen(self, minus=0):
         """Set numpy random generator state from restart."""
         n_children_spawned = self.cstep - minus
@@ -403,7 +391,6 @@ class REPEX_state:
             # should probably add a check for stopping when all workers
             # are free to close the while loop, but for now when
             # cstep >= tsteps we return false.
-            # self.save_rgen()
             self.print_end()
             self.write_toml()
             logger.info("date: " + datetime.now().strftime(DATE_FORMAT))
@@ -975,7 +962,6 @@ class REPEX_state:
         if self.printing():
             self.print_shooted(md_items, pn_news)
         # save for possible restart
-        # self.save_rgen()
         self.write_toml()
 
         return md_items

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -502,7 +502,7 @@ class REPEX_state:
 
         equal = equal_minus and equal_pos
 
-        out = np.zeros(shape=sorted_non_locked.shape, dtype="float")
+        out = np.zeros(shape=sorted_non_locked.shape, dtype="float128")
         if equal:
             # All trajectories have equal weights, run fast algorithm
             # run_fast
@@ -582,8 +582,8 @@ class REPEX_state:
 
     def quick_prob(self, arr):
         """Quick P matrix calculation for specific W matrix."""
-        total_traj_prob = np.ones(shape=arr.shape[0], dtype="float")
-        out_mat = np.zeros(shape=arr.shape, dtype="float")
+        total_traj_prob = np.ones(shape=arr.shape[0], dtype="float128")
+        out_mat = np.zeros(shape=arr.shape, dtype="float128")
         working_mat = np.where(arr != 0, 1, 0)  # convert non-zero numbers to 1
 
         for i, column in enumerate(working_mat.T[::-1]):
@@ -601,8 +601,8 @@ class REPEX_state:
         """Quick P matrix calculation for specific W matrix."""
         # TODO: DEBUG CODE
         # ONLY HERE TO DEBUG THE OTHER METHODS
-        total_traj_prob = np.ones(shape=arr.shape[0], dtype="float")
-        out_mat = np.zeros(shape=arr.shape, dtype="float")
+        total_traj_prob = np.ones(shape=arr.shape[0], dtype="float128")
+        out_mat = np.zeros(shape=arr.shape, dtype="float128")
 
         force_arr = arr.copy()
         # Force everything to be identical
@@ -620,7 +620,7 @@ class REPEX_state:
 
     def permanent_prob(self, arr):
         """P matrix calculation for specific W matrix."""
-        out = np.zeros(shape=arr.shape, dtype="float")
+        out = np.zeros(shape=arr.shape, dtype="float128")
         # Don't overwrite input arr
         scaled_arr = arr.copy()
         n = len(scaled_arr)
@@ -643,7 +643,7 @@ class REPEX_state:
 
     def random_prob(self, arr, n=10_000):
         """P matrix calculation for specific W matrix."""
-        out = np.eye(len(arr), dtype="float")
+        out = np.eye(len(arr), dtype="float128")
         current_state = np.eye(len(arr))
         choices = len(arr) // 2
         even = choices * 2 == len(arr)
@@ -703,7 +703,7 @@ class REPEX_state:
             else:
                 return -1
 
-        row_comb = np.sum(M, axis=0, dtype="float")
+        row_comb = np.sum(M, axis=0, dtype="float128")
         n = len(M)
 
         total = 0
@@ -916,7 +916,7 @@ class REPEX_state:
                 }
                 out_traj = self.pstore.output(self.cstep, data)
                 self.traj_data[traj_num] = {
-                    "frac": np.zeros(self.n, dtype="float"),
+                    "frac": np.zeros(self.n, dtype="float128"),
                     "max_op": out_traj.ordermax,
                     "min_op": out_traj.ordermin,
                     "length": out_traj.length,
@@ -1008,7 +1008,7 @@ class REPEX_state:
                 "length": paths[i + 1].length,
                 "adress": paths[i + 1].adress,
                 "weights": paths[i + 1].weights,
-                "frac": np.array(frac, dtype="float"),
+                "frac": np.array(frac, dtype="float128"),
             }
         # add minus path:
         paths[0].weights = (1.0,)
@@ -1026,7 +1026,7 @@ class REPEX_state:
             "length": paths[0].length,
             "weights": paths[0].weights,
             "adress": paths[0].adress,
-            "frac": np.array(frac, dtype="float"),
+            "frac": np.array(frac, dtype="float128"),
         }
 
     def pattern_header(self):

--- a/test/repex/test_repex.py
+++ b/test/repex/test_repex.py
@@ -1,20 +1,28 @@
 import os
 from pathlib import PosixPath
+
+import tomli
+
 from infretis.classes.repex import REPEX_state
+
 
 def test_rgen_io(tmp_path: PosixPath) -> None:
     """Test repex rgen and rgen spawn reproducability."""
     state = REPEX_state(
-        {"current": {"size": 1},
-         "dask": {"workers": 1},
-         "simulation": {}}
+        {
+            "current": {"size": 1, "cstep": 0},
+            "dask": {"workers": 1},
+            "simulation": {},
+        }
     )
     folder = tmp_path / "temp"
     folder.mkdir()
     os.chdir(folder)
 
     # save initial state for restart
-    state.save_rgen()
+    state.write_toml()
+
+    # generate numbers
     save_rng = []
     save_rng_child = []
     for i in range(5):
@@ -23,11 +31,10 @@ def test_rgen_io(tmp_path: PosixPath) -> None:
         save_rng_child.append(child.random())
 
     # restart with the "restarted_from" keyword
-    state = REPEX_state(
-        {"current": {"size": 1, "restarted_from": {}},
-         "dask": {"workers": 1},
-         "simulation": {}}
-    )
+    with open("restart.toml", mode="rb") as f:
+        config = tomli.load(f)
+        config["current"]["restarted_from"] = {}
+    state = REPEX_state(config)
 
     # test that the numbers are the same
     for rng, child_rng in zip(save_rng, save_rng_child):

--- a/test/simulations/data/10steps_wf/restart.toml
+++ b/test/simulations/data/10steps_wf/restart.toml
@@ -209,3 +209,12 @@ size = 8
     "0.0",
     "0.0",
 ]
+
+[current.rng_state]
+bit_generator = "PCG64"
+has_uint32 = 0
+uinteger = 0
+
+[current.rng_state.state]
+state = 276937304969521971854545303600510771084
+inc = 87136372517582989555478159403783844777

--- a/test/simulations/data/20steps_wf/restart.toml
+++ b/test/simulations/data/20steps_wf/restart.toml
@@ -209,3 +209,12 @@ size = 8
     "1.0",
     "0.0",
 ]
+
+[current.rng_state]
+bit_generator = "PCG64"
+has_uint32 = 0
+uinteger = 0
+
+[current.rng_state.state]
+state = 149016169330749493134370448296911543734
+inc = 87136372517582989555478159403783844777

--- a/test/simulations/data/30steps_wf/restart.toml
+++ b/test/simulations/data/30steps_wf/restart.toml
@@ -209,3 +209,12 @@ size = 8
     "1.0",
     "0.0",
 ]
+
+[current.rng_state]
+bit_generator = "PCG64"
+has_uint32 = 0
+uinteger = 0
+
+[current.rng_state.state]
+state = 326349929631057323353968040272265211693
+inc = 87136372517582989555478159403783844777

--- a/test/simulations/test_run_infretis.py
+++ b/test/simulations/test_run_infretis.py
@@ -121,7 +121,7 @@ def test_restart_multiple_w(tmp_path: PosixPath) -> None:
     # start 4w 5s simulation
     try:
         check_output(
-            ["infretisrun", "-i", "infretis.toml"], stderr=STDOUT, timeout=3
+            ["infretisrun", "-i", "infretis.toml"], stderr=STDOUT, timeout=5
         )
     except Exception:
         pass


### PR DESCRIPTION
We save the random state in restart.toml, and the number of rgen children spawned equals now cstep.
