### PR TITLE
Fix crash caused by incomplete removal of infretis.restart file

### DIFF
--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -40,7 +40,7 @@ class REPEX_state:
         self.config = config
         # set rng
         if "restarted_from" in config["current"]:
-            self.set_rgen(minus=self.workers - 1)
+            self.set_rgen()
         else:
             self.rgen = default_rng(seed=config.get("seed", 0))
 
@@ -366,11 +366,10 @@ class REPEX_state:
         ]
         return locks
 
-    def set_rgen(self, minus=0):
+    def set_rgen(self):
         """Set numpy random generator state from restart."""
-        n_children_spawned = self.cstep - minus
         seed_sequence = np.random.SeedSequence(
-            entropy=0, n_children_spawned=n_children_spawned
+            entropy=0, n_children_spawned=self.cstep
         )
         self.rgen = default_rng(seed_sequence)
         self.rgen.bit_generator.state = self.config["current"]["rng_state"]

--- a/test/simulations/test_run_infretis.py
+++ b/test/simulations/test_run_infretis.py
@@ -12,6 +12,7 @@ import tomli_w
 
 
 def get_diff_data(inp1, inp2):
+    "Check the difference between two infretis_data.txt files in a simple way."
     diffps, diffms = [], []
     with open(inp1) as left, open(inp2) as right:
         diffs = difflib.unified_diff(left.readlines(), right.readlines(), n=0)

--- a/test/simulations/test_run_infretis.py
+++ b/test/simulations/test_run_infretis.py
@@ -1,4 +1,5 @@
 """Test methods for doing TIS."""
+import difflib
 import filecmp
 import os
 import shutil
@@ -8,6 +9,21 @@ from subprocess import STDOUT, check_output
 import pytest
 import tomli
 import tomli_w
+
+
+def get_diff_data(inp1, inp2):
+    diffps, diffms = [], []
+    with open(inp1) as left, open(inp2) as right:
+        diffs = difflib.unified_diff(left.readlines(), right.readlines(), n=0)
+        for diff in diffs:  # difference is empty if no differences
+            if "+\t" in diff[:2]:
+                diffps.append(sum([int(i) for i in diff if i.isdigit()]))
+            if "-\t" in diff[:2]:
+                diffms.append(sum([int(i) for i in diff if i.isdigit()]))
+    diffnum = 0
+    for diffp, diffm in zip(diffps, diffms):
+        diffnum += abs(diffp - diffm)
+    return diffnum
 
 
 def read_simlogw(inp, workers=4, restart=False):
@@ -92,6 +108,36 @@ def test_run_airetis_wf(tmp_path: PosixPath) -> None:
     # nb: technically num_files == 24, but due to restarts pn_olds get reset.
     num_files = len(os.listdir("load"))
     assert num_files < 40
+
+    # run 30 steps without restart
+    with open("infretis.toml", mode="rb") as f:
+        config = tomli.load(f)
+        config["simulation"]["steps"] = 30
+        config["output"]["delete_old_all"] = False
+    with open("infretis.toml", "wb") as f:
+        tomli_w.dump(config, f)
+
+    success = os.system("infretisrun -i infretis.toml >| out.txt")
+    items = [
+        ("infretis_data_1.txt", "infretis_data.txt"),
+        ("restart.toml", "restart.toml"),
+    ]
+    assert (
+        get_diff_data(
+            "infretis_data_1.txt",
+            f"{basepath}/data/30steps_wf/infretis_data.txt",
+        )
+        < 5
+    )
+    with open("restart.toml", mode="rb") as f:
+        config = tomli.load(f)
+        config["output"]["data_file"] = "./infretis_data.txt"
+        config["output"]["delete_old_all"] = True
+    with open("restart.toml", "wb") as f:
+        tomli_w.dump(config, f)
+    assert filecmp.cmp(
+        "./restart.toml", f"{basepath}/data/30steps_wf/restart.toml"
+    )
 
 
 @pytest.mark.heavy

--- a/test/simulations/test_run_infretis.py
+++ b/test/simulations/test_run_infretis.py
@@ -118,10 +118,6 @@ def test_run_airetis_wf(tmp_path: PosixPath) -> None:
         tomli_w.dump(config, f)
 
     success = os.system("infretisrun -i infretis.toml >| out.txt")
-    items = [
-        ("infretis_data_1.txt", "infretis_data.txt"),
-        ("restart.toml", "restart.toml"),
-    ]
     assert (
         get_diff_data(
             "infretis_data_1.txt",


### PR DESCRIPTION
a crash can occur because the number of random gen childs can accidentally be set to negative children. this PR fixes this issue. Additionally, i extend the simulation test to reproduce 30 steps without restart. 