### PR TITLE
change from float128 to longdouble

### DIFF
--- a/infretis/classes/engines/gromacs.py
+++ b/infretis/classes/engines/gromacs.py
@@ -182,7 +182,7 @@ class GromacsEngine(EngineBase):
                 )
                 raise ValueError(msg)
             if key in ["tc-grps", "tc_grps"]:
-                self.n_tc_grps = len(val.split())
+                self.n_tc_grps = len(val.split(";")[0].split())
 
         self.temperature = temperature
         self.kb = 0.0083144621  # kJ/(K*mol)

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -53,8 +53,8 @@ def write_lammpstrj(
     filemode = "a" if append else "w"
     with open(outfile, filemode) as writefile:
         to_write = (
-            f"ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n{pos.shape[0]}\n \
-ITEM: BOX BOUNDS xy xz yz pp pp pp\n"
+            f"ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n{pos.shape[0]}\n\
+ITEM: BOX BOUNDS pp pp pp\n"
             ""
         )
 

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -488,7 +488,7 @@ class REPEX_state:
 
         equal = equal_minus and equal_pos
 
-        out = np.zeros(shape=sorted_non_locked.shape, dtype="float128")
+        out = np.zeros(shape=sorted_non_locked.shape, dtype="longdouble")
         if equal:
             # All trajectories have equal weights, run fast algorithm
             # run_fast
@@ -568,8 +568,8 @@ class REPEX_state:
 
     def quick_prob(self, arr):
         """Quick P matrix calculation for specific W matrix."""
-        total_traj_prob = np.ones(shape=arr.shape[0], dtype="float128")
-        out_mat = np.zeros(shape=arr.shape, dtype="float128")
+        total_traj_prob = np.ones(shape=arr.shape[0], dtype="longdouble")
+        out_mat = np.zeros(shape=arr.shape, dtype="longdouble")
         working_mat = np.where(arr != 0, 1, 0)  # convert non-zero numbers to 1
 
         for i, column in enumerate(working_mat.T[::-1]):
@@ -587,8 +587,8 @@ class REPEX_state:
         """Quick P matrix calculation for specific W matrix."""
         # TODO: DEBUG CODE
         # ONLY HERE TO DEBUG THE OTHER METHODS
-        total_traj_prob = np.ones(shape=arr.shape[0], dtype="float128")
-        out_mat = np.zeros(shape=arr.shape, dtype="float128")
+        total_traj_prob = np.ones(shape=arr.shape[0], dtype="longdouble")
+        out_mat = np.zeros(shape=arr.shape, dtype="longdouble")
 
         force_arr = arr.copy()
         # Force everything to be identical
@@ -606,7 +606,7 @@ class REPEX_state:
 
     def permanent_prob(self, arr):
         """P matrix calculation for specific W matrix."""
-        out = np.zeros(shape=arr.shape, dtype="float128")
+        out = np.zeros(shape=arr.shape, dtype="longdouble")
         # Don't overwrite input arr
         scaled_arr = arr.copy()
         n = len(scaled_arr)
@@ -629,7 +629,7 @@ class REPEX_state:
 
     def random_prob(self, arr, n=10_000):
         """P matrix calculation for specific W matrix."""
-        out = np.eye(len(arr), dtype="float128")
+        out = np.eye(len(arr), dtype="longdouble")
         current_state = np.eye(len(arr))
         choices = len(arr) // 2
         even = choices * 2 == len(arr)
@@ -689,7 +689,7 @@ class REPEX_state:
             else:
                 return -1
 
-        row_comb = np.sum(M, axis=0, dtype="float128")
+        row_comb = np.sum(M, axis=0, dtype="longdouble")
         n = len(M)
 
         total = 0
@@ -902,7 +902,7 @@ class REPEX_state:
                 }
                 out_traj = self.pstore.output(self.cstep, data)
                 self.traj_data[traj_num] = {
-                    "frac": np.zeros(self.n, dtype="float128"),
+                    "frac": np.zeros(self.n, dtype="longdouble"),
                     "max_op": out_traj.ordermax,
                     "min_op": out_traj.ordermin,
                     "length": out_traj.length,
@@ -993,7 +993,7 @@ class REPEX_state:
                 "length": paths[i + 1].length,
                 "adress": paths[i + 1].adress,
                 "weights": paths[i + 1].weights,
-                "frac": np.array(frac, dtype="float128"),
+                "frac": np.array(frac, dtype="longdouble"),
             }
         # add minus path:
         paths[0].weights = (1.0,)
@@ -1011,7 +1011,7 @@ class REPEX_state:
             "length": paths[0].length,
             "weights": paths[0].weights,
             "adress": paths[0].adress,
-            "frac": np.array(frac, dtype="float128"),
+            "frac": np.array(frac, dtype="longdouble"),
         }
 
     def pattern_header(self):


### PR DESCRIPTION
* np.float128 is hardware specific and only exists for certain hardware. infretis cannot run when np.float128 does not exist.
* longdouble, like np.float128 is system specific, and defaults to "double" for when np.float128 does not exist. https://github.com/numpy/numpy/issues/22796
* This PR should technically not break anything, but also will allow macos users like me to directly run infretis