### PR TITLE
Python 3.13 compability

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -23,7 +23,7 @@ jobs:
         id: setuppy
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: "Set up Poetry"
         uses: abatilo/actions-poetry@v2

--- a/.github/workflows/heavy.yaml
+++ b/.github/workflows/heavy.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/heavy.yaml
+++ b/.github/workflows/heavy.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-and-type.yaml
+++ b/.github/workflows/lint-and-type.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pydocstyle.yaml
+++ b/.github/workflows/pydocstyle.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: "Install pydocstyle"
         run: pip install pydocstyle

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: "Install codespell"
         run: pip install codespell

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<=3.13"
 numpy = "^1.26.0"
 matplotlib = "^3.7.2"
 tomli = "^2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<=3.13"
+python = ">=3.11,<=3.13"
 numpy = "^1.26.0"
-matplotlib = "^3.7.2"
 tomli = "^2.0.1"
 tomli-w = "^1.0.0"
 turtlemd = "^2023.3"
@@ -48,7 +47,7 @@ show_error_codes = true
 plugins = "numpy.typing.mypy_plugin"
 
 [[tool.mypy.overrides]]
-module = ["matplotlib.*", "scipy.optimize.*", "turtlemd.*", "tomli"]
+module = ["scipy.optimize.*", "turtlemd.*", "tomli"]
 ignore_missing_imports = true
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Python 3.13 just released and seem to pass all tests when run locally on my ubuntu workstation.

Should we change all the other workflows to be done for 3.13 or keep them at 3.12? @andersle 