### PR TITLE
Lambda -1 implementation:

### DIFF
--- a/infretis/bin.py
+++ b/infretis/bin.py
@@ -1,4 +1,5 @@
 """The functions to be used to run infretis via the terminal."""
+
 import argparse
 
 from infretis.scheduler import scheduler

--- a/infretis/classes/engines/enginebase.py
+++ b/infretis/classes/engines/enginebase.py
@@ -1,4 +1,5 @@
 """Base engine class."""
+
 from __future__ import annotations
 
 import logging
@@ -426,9 +427,10 @@ class EngineBase(metaclass=ABCMeta):
         """
         reg = re.compile(rf"(.*?){delim}")
         written = set()
-        with open(sourcefile, encoding="utf-8") as infile, open(
-            outputfile, mode="w", encoding="utf-8"
-        ) as outfile:
+        with (
+            open(sourcefile, encoding="utf-8") as infile,
+            open(outputfile, mode="w", encoding="utf-8") as outfile,
+        ):
             for line in infile:
                 to_write = line
                 match = reg.match(line)

--- a/infretis/classes/engines/engineparts.py
+++ b/infretis/classes/engines/engineparts.py
@@ -1,4 +1,5 @@
 """Helper methods for MD engines."""
+
 import logging
 import math
 import os

--- a/infretis/classes/engines/gromacs.py
+++ b/infretis/classes/engines/gromacs.py
@@ -1,4 +1,5 @@
 """Gromacs engine."""
+
 from __future__ import annotations
 
 import logging

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -1,4 +1,5 @@
 """Define the engine for using LAMMPS."""
+
 from __future__ import annotations
 
 import logging

--- a/infretis/classes/engines/turtlemdengine.py
+++ b/infretis/classes/engines/turtlemdengine.py
@@ -3,6 +3,7 @@
 This module defines a class for using the TurtleMD.
 
 """
+
 from __future__ import annotations
 
 import logging

--- a/infretis/classes/formatter.py
+++ b/infretis/classes/formatter.py
@@ -1,4 +1,5 @@
 """Handle formatting of files."""
+
 from __future__ import annotations
 
 import logging

--- a/infretis/classes/orderparameter.py
+++ b/infretis/classes/orderparameter.py
@@ -1,4 +1,5 @@
 """Define the OrderParameter class."""
+
 from __future__ import annotations
 
 import logging

--- a/infretis/classes/path.py
+++ b/infretis/classes/path.py
@@ -1,4 +1,5 @@
 """Define the path class."""
+
 from __future__ import annotations
 
 import logging

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -1030,7 +1030,7 @@ class REPEX_state:
         ens_intfs = []
 
         # set intfs for [0-] and [0+]
-        if lambda_minus_one is not None:
+        if lambda_minus_one is not False:
             ens_intfs.append(
                 [lambda_minus_one, (lambda_minus_one + intfs[0]) / 2, intfs[0]]
             )
@@ -1054,7 +1054,7 @@ class REPEX_state:
                 "ens_name": f"{i:03d}",
                 "start_cond": (
                     ["L", "R"]
-                    if lambda_minus_one is not None and i == 0
+                    if lambda_minus_one is not False and i == 0
                     else ("R" if i == 0 else "L")
                 ),
             }

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -115,6 +115,11 @@ class REPEX_state:
         return self.config["simulation"]["tis_set"].get("interface_cap", None)
 
     @property
+    def lambda_minus_one(self):
+        """Retrieve lambda_minus_one from config dict."""
+        return self.config["simulation"]["tis_set"].get("lambda_minus_one", None)
+        
+    @property
     def pattern(self):
         """Retrieve pattern_file from config dict."""
         return self.config["output"].get("pattern", False)
@@ -301,9 +306,7 @@ class REPEX_state:
         for key in ["moves", "trial_len", "trial_op", "generated"]:
             md_items[key] = []
 
-        md_items["lambda_minus_one"] = self.config["simulation"].get(
-            "lambda_minus_one", None
-        )
+        md_items["lambda_minus_one"] = self.lambda_minus_one
 
         return md_items
 
@@ -969,8 +972,8 @@ class REPEX_state:
             paths[i + 1].weights = calc_cv_vector(
                 paths[i + 1],
                 self.config["simulation"]["interfaces"],
-                self.config["simulation"].get("lambda_minus_one", None),
                 self.mc_moves,
+                lambda_minus_one=self.lambda_minus_one,                
                 cap=self.cap,
             )
             self.add_traj(
@@ -1026,9 +1029,7 @@ class REPEX_state:
     def initiate_ensembles(self):
         """Create all the ensemble dicts from the *toml config dict."""
         intfs = self.config["simulation"]["interfaces"]
-        lambda_minus_one = self.config["simulation"].get(
-            "lambda_minus_one", None
-        )
+        lambda_minus_one = self.lambda_minus_one       
         ens_intfs = []
 
         # set intfs for [0-] and [0+]

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -117,8 +117,10 @@ class REPEX_state:
     @property
     def lambda_minus_one(self):
         """Retrieve lambda_minus_one from config dict."""
-        return self.config["simulation"]["tis_set"].get("lambda_minus_one", None)
-        
+        return self.config["simulation"]["tis_set"].get(
+            "lambda_minus_one", None
+        )
+
     @property
     def pattern(self):
         """Retrieve pattern_file from config dict."""
@@ -973,7 +975,7 @@ class REPEX_state:
                 paths[i + 1],
                 self.config["simulation"]["interfaces"],
                 self.mc_moves,
-                lambda_minus_one=self.lambda_minus_one,                
+                lambda_minus_one=self.lambda_minus_one,
                 cap=self.cap,
             )
             self.add_traj(
@@ -1029,7 +1031,7 @@ class REPEX_state:
     def initiate_ensembles(self):
         """Create all the ensemble dicts from the *toml config dict."""
         intfs = self.config["simulation"]["interfaces"]
-        lambda_minus_one = self.lambda_minus_one       
+        lambda_minus_one = self.lambda_minus_one
         ens_intfs = []
 
         # set intfs for [0-] and [0+]

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -115,13 +115,6 @@ class REPEX_state:
         return self.config["simulation"]["tis_set"].get("interface_cap", None)
 
     @property
-    def lambda_minus_one(self):
-        """Retrieve lambda_minus_one from config dict."""
-        return self.config["simulation"]["tis_set"].get(
-            "lambda_minus_one", None
-        )
-
-    @property
     def pattern(self):
         """Retrieve pattern_file from config dict."""
         return self.config["output"].get("pattern", False)
@@ -307,8 +300,6 @@ class REPEX_state:
         # empty / update md_items:
         for key in ["moves", "trial_len", "trial_op", "generated"]:
             md_items[key] = []
-
-        md_items["lambda_minus_one"] = self.lambda_minus_one
 
         return md_items
 
@@ -975,7 +966,9 @@ class REPEX_state:
                 paths[i + 1],
                 self.config["simulation"]["interfaces"],
                 self.mc_moves,
-                lambda_minus_one=self.lambda_minus_one,
+                lambda_minus_one=self.config["simulation"]["tis_set"][
+                    "lambda_minus_one"
+                ],
                 cap=self.cap,
             )
             self.add_traj(
@@ -1031,7 +1024,9 @@ class REPEX_state:
     def initiate_ensembles(self):
         """Create all the ensemble dicts from the *toml config dict."""
         intfs = self.config["simulation"]["interfaces"]
-        lambda_minus_one = self.lambda_minus_one
+        lambda_minus_one = self.config["simulation"]["tis_set"][
+            "lambda_minus_one"
+        ]
         ens_intfs = []
 
         # set intfs for [0-] and [0+]

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -1,4 +1,5 @@
 """Defines the main REPEX class for path handling and permanent calc."""
+
 import logging
 import os
 import sys
@@ -300,8 +301,10 @@ class REPEX_state:
         for key in ["moves", "trial_len", "trial_op", "generated"]:
             md_items[key] = []
 
-        md_items["lambda_minus_one"] = self.config["simulation"].get("lambda_minus_one", None)
-        
+        md_items["lambda_minus_one"] = self.config["simulation"].get(
+            "lambda_minus_one", None
+        )
+
         return md_items
 
     def add_traj(self, ens, traj, valid, count=True, n=0):
@@ -1023,12 +1026,16 @@ class REPEX_state:
     def initiate_ensembles(self):
         """Create all the ensemble dicts from the *toml config dict."""
         intfs = self.config["simulation"]["interfaces"]
-        lambda_minus_one = self.config["simulation"].get("lambda_minus_one", None)        
+        lambda_minus_one = self.config["simulation"].get(
+            "lambda_minus_one", None
+        )
         ens_intfs = []
 
         # set intfs for [0-] and [0+]
-        if lambda_minus_one != None:
-            ens_intfs.append([lambda_minus_one, (lambda_minus_one + intfs[0])/2, intfs[0]])
+        if lambda_minus_one is not None:
+            ens_intfs.append(
+                [lambda_minus_one, (lambda_minus_one + intfs[0]) / 2, intfs[0]]
+            )
         else:
             ens_intfs.append([float("-inf"), intfs[0], intfs[0]])
         ens_intfs.append([intfs[0], intfs[0], intfs[-1]])
@@ -1047,7 +1054,11 @@ class REPEX_state:
                 "tis_set": self.config["simulation"]["tis_set"],
                 "mc_move": self.config["simulation"]["shooting_moves"][i],
                 "ens_name": f"{i:03d}",
-                "start_cond": ["L", "R"] if lambda_minus_one != None and i == 0 else ("R" if i == 0 else "L"),
+                "start_cond": (
+                    ["L", "R"]
+                    if lambda_minus_one is not None and i == 0
+                    else ("R" if i == 0 else "L")
+                ),
             }
 
         self.ensembles = pensembles

--- a/infretis/classes/system.py
+++ b/infretis/classes/system.py
@@ -1,4 +1,5 @@
 """Defines the snapshot system class."""
+
 from __future__ import annotations
 
 import logging

--- a/infretis/core/core.py
+++ b/infretis/core/core.py
@@ -1,4 +1,5 @@
 """Methods for XYZ."""
+
 from __future__ import annotations
 
 import errno

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -97,7 +97,7 @@ def run_md(md_items: dict[str, Any]) -> dict[str, Any]:
                 trial,
                 md_items["interfaces"],
                 md_items["mc_moves"],
-                md_items["lambda_minus_one"],                
+                md_items["lambda_minus_one"],
                 cap=md_items["cap"],
                 minus=minus,
             )

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -93,7 +93,6 @@ def run_md(md_items: dict[str, Any]) -> dict[str, Any]:
         md_items["generated"].append(trial.generated)
         if status == "ACC":
             minus = True if ens_num < 0 else False
-            print(picked[ens_num])
             trial.weights = calc_cv_vector(
                 trial,
                 md_items["interfaces"],
@@ -133,7 +132,7 @@ def calc_cv_vector(
 
     cv = []
     if minus:
-        if lambda_minus_one is not None:
+        if lambda_minus_one is not False:
             return (1.0 if lambda_minus_one <= path_max else 0.0,)
         else:
             return (1.0 if interfaces[0] <= path_max else 0.0,)

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -111,7 +111,7 @@ def calc_cv_vector(
     path: InfPath,
     interfaces: list[float],
     moves: list[str],
-    lambda_minus_one: float | None = None,
+    lambda_minus_one: float | bool = False,
     cap: float | None = None,
     minus: bool = False,
 ) -> tuple[float, ...]:

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -96,8 +96,8 @@ def run_md(md_items: dict[str, Any]) -> dict[str, Any]:
             trial.weights = calc_cv_vector(
                 trial,
                 md_items["interfaces"],
-                md_items["lambda_minus_one"],
                 md_items["mc_moves"],
+                md_items["lambda_minus_one"],                
                 cap=md_items["cap"],
                 minus=minus,
             )
@@ -110,8 +110,8 @@ def run_md(md_items: dict[str, Any]) -> dict[str, Any]:
 def calc_cv_vector(
     path: InfPath,
     interfaces: list[float],
-    lambda_minus_one: float,
     moves: list[str],
+    lambda_minus_one: float | None = None,
     cap: float | None = None,
     minus: bool = False,
 ) -> tuple[float, ...]:
@@ -120,6 +120,7 @@ def calc_cv_vector(
     Args:
         path: The path to calculate weights for.
         interfaces: The positions of the interfaces.
+        lambda_minus_one: For permeability calculations
         moves: The MC moves performed.
         cap: The cap value for the Wire Fencing (wf) move.
         minus: Indicate if the math is a minus path or not.

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -93,11 +93,12 @@ def run_md(md_items: dict[str, Any]) -> dict[str, Any]:
         md_items["generated"].append(trial.generated)
         if status == "ACC":
             minus = True if ens_num < 0 else False
+            print(picked[ens_num])
             trial.weights = calc_cv_vector(
                 trial,
                 md_items["interfaces"],
                 md_items["mc_moves"],
-                md_items["lambda_minus_one"],
+                picked[ens_num]["ens"]["tis_set"]["lambda_minus_one"],
                 cap=md_items["cap"],
                 minus=minus,
             )

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -905,16 +905,25 @@ def retis_swap_zero(
     logger.info("Point is %s", phase_point.order)
     engine1.dump_phasepoint(phase_point, "second")
     path0.append(phase_point)
-    # Reject the zero swap with status 0-L when the 0- path is RML or LML (Sina) 
-    if "L" in path_old0.check_interfaces(ens_set0["interfaces"])[1:2]:
+
+    if (
+        (
+            "L" not in set(ens_set0["start_cond"])  # if not lambda_minus_one, 0- start_cond is ['R']
+            and "L" in path0.check_interfaces(ens_set0["interfaces"])[:2]
+        ) 
+        or (
+            "L" in set(ens_set0["start_cond"])      # if lambda_minus_one, 0- start_cond is ['L', 'R']
+            and "R" in set(ens_set0["start_cond"]) 
+            and "L" in path_old0.check_interfaces(ens_set0["interfaces"])[1:2] # reject 0- RML and LML swap with 0+
+        )
+    ):
         path0.status = "0-L"
     elif path0.length == maxlen0:
         path0.status = "BTX"
     elif path0.length < 3:
-        path0.status = "BTS"
+        path0.status = "BTS"       
     else:
         path0.status = "ACC"
-    # print(path0.status)
 
     # 2. Generate path for [0^+] from [0^-]:
     logger.info("Creating path for [0^+] from [0^-]")
@@ -1105,14 +1114,14 @@ def quantis_swap_zero(
         with rare event simulations [https://doi.org/10.1021/acs.jctc.5b00012]
 
     Todo:
-        * Implement the option to mix engines in [eninge] and [engine2], as
+        * Implement the option to mix engines in [eninge] and [engine2], as
         quantis now only works properly with the same engine in all ensembles
         due to different units and file formats being used. For example, to
         extract a  configuration from [0+] into [0-] requires some processing.
         * Add options to relax crossing condition and energy acceptance rule
         * Option to do 'wf' or nah?
         * After performing a swap, another swap that happens before any moves
-        in the ensembles [0-] and [0+] are performed, we get back the original
+        in the ensembles [0-] and [0+] are performed, we get back the original
         paths. Should avoid zero swap if this is the case (see retis_swap_0)
 
     """

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -192,7 +192,7 @@ def check_config(config: dict) -> None:
     n_sh_moves = len(sh_moves)
     intf_cap = config["simulation"]["tis_set"].get("interface_cap", False)
     quantis = config["simulation"]["tis_set"].get("quantis", False)
-    lambda_minus_one = config["simulation"].get("lambda_minus_one", None)
+    lambda_minus_one = config["simulation"]["tis_set"].get("lambda_minus_one", None)
 
     if lambda_minus_one is not None and lambda_minus_one >= intf[0]:
         raise TOMLConfigError(

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -169,6 +169,10 @@ def setup_config(
     # set the keywords once
     quantis = config["simulation"]["tis_set"].get("quantis", False)
     config["simulation"]["tis_set"]["quantis"] = quantis
+
+    l_1 = config["simulation"]["tis_set"].get("lambda_minus_one", False)
+    config["simulation"]["tis_set"]["lambda_minus_one"] = l_1
+
     if quantis and not has_ens_engs:
         config["simulation"]["ensemble_engines"][0] = ["engine0"]
     accept_all = config["simulation"]["tis_set"].get("accept_all", False)

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -191,6 +191,16 @@ def check_config(config: dict) -> None:
     sh_moves = config["simulation"]["shooting_moves"]
     n_sh_moves = len(sh_moves)
     intf_cap = config["simulation"]["tis_set"].get("interface_cap", False)
+    quantis = config["simulation"]["tis_set"].get("quantis", False)
+    lambda_minus_one = config["simulation"].get("lambda_minus_one", None)
+
+    if lambda_minus_one is not None and lambda_minus_one >= intf[0]:
+        raise TOMLConfigError(
+            "lambda_minus_one interface must be less than the first interface!"
+        )
+
+    if quantis and lambda_minus_one:
+        raise TOMLConfigError("Cannot run quantis with lambda_minus_one!")
 
     if n_ens < 2:
         raise TOMLConfigError("Define at least 2 interfaces!")

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -197,10 +197,10 @@ def check_config(config: dict) -> None:
     intf_cap = config["simulation"]["tis_set"].get("interface_cap", False)
     quantis = config["simulation"]["tis_set"].get("quantis", False)
     lambda_minus_one = config["simulation"]["tis_set"].get(
-        "lambda_minus_one", None
+        "lambda_minus_one", False
     )
 
-    if lambda_minus_one is not None and lambda_minus_one >= intf[0]:
+    if lambda_minus_one is not False and lambda_minus_one >= intf[0]:
         raise TOMLConfigError(
             "lambda_minus_one interface must be less than the first interface!"
         )

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -192,7 +192,9 @@ def check_config(config: dict) -> None:
     n_sh_moves = len(sh_moves)
     intf_cap = config["simulation"]["tis_set"].get("interface_cap", False)
     quantis = config["simulation"]["tis_set"].get("quantis", False)
-    lambda_minus_one = config["simulation"]["tis_set"].get("lambda_minus_one", None)
+    lambda_minus_one = config["simulation"]["tis_set"].get(
+        "lambda_minus_one", None
+    )
 
     if lambda_minus_one is not None and lambda_minus_one >= intf[0]:
         raise TOMLConfigError(

--- a/infretis/tools/generate_H2_loadpaths.py
+++ b/infretis/tools/generate_H2_loadpaths.py
@@ -6,6 +6,7 @@ Usage:
     # e.g. from infretis/examples/gromacs/H2
     python ../../../infretis/tools/generate_H2_loadpaths.py
 """
+
 from pathlib import Path
 
 import numpy as np

--- a/test/simulations/data/10steps_wf/restart.toml
+++ b/test/simulations/data/10steps_wf/restart.toml
@@ -68,6 +68,7 @@ allowmaxlength = false
 zero_momentum = false
 n_jumps = 6
 quantis = false
+lambda_minus_one = false
 accept_all = false
 
 [engine]

--- a/test/simulations/data/20steps_wf/restart.toml
+++ b/test/simulations/data/20steps_wf/restart.toml
@@ -68,6 +68,7 @@ allowmaxlength = false
 zero_momentum = false
 n_jumps = 6
 quantis = false
+lambda_minus_one = false
 accept_all = false
 
 [engine]

--- a/test/simulations/data/30steps_wf/restart.toml
+++ b/test/simulations/data/30steps_wf/restart.toml
@@ -68,6 +68,7 @@ allowmaxlength = false
 zero_momentum = false
 n_jumps = 6
 quantis = false
+lambda_minus_one = false
 accept_all = false
 
 [engine]

--- a/test/tis/test_tis.py
+++ b/test/tis/test_tis.py
@@ -432,3 +432,22 @@ def test_zero_swaps(
         ] == pytest.approx(
             [pp.order[0] for pp in swapped_paths[3].phasepoints], rel=1e-5
         )
+
+    # test the lambda_minus_one feature for retis_swap_zero
+    if zero_swap_move.__name__ == "retis_swap_zero":
+        pathdir = PosixPath(tmp_dir / "zero_swap_move")
+        pathdir.mkdir()
+        turtle.exe_dir = str(pathdir.resolve())
+        intf_minus = (-1.05, -1.02, -0.99)
+        picked[-1]["ens"]["interfaces"] = intf_minus
+        picked[-1]["ens"]["start_cond"] = ["L", "R"]
+
+        success, [new_path0, new_path1], status = zero_swap_move(
+            picked, engines
+        )
+
+        # LMR path should be generated
+        start, end, middle,  _ = new_path0.check_interfaces(intf_minus)
+        assert start == "L"
+        assert end == "R"
+        assert middle == "M"


### PR DESCRIPTION
* The Lambda -1 interface can be set under the [simulation] section in the TOML file (e.g., lambda_minus_one = -34).

* The starting condition can be either L or R in the 000 ensemble.

* All 0- paths hitting the Lambda -1 interface will be accepted if they are valid (0- paths can be RML, RMR, LMR, LML).

* For RETIS zero swap, the swap move will be rejected if the 0- path is RML or LML (with status 0-L).