### PR TITLE
Lmp compression

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,4 +47,4 @@ jobs:
         run: poetry install
 
       - name: "Run pytest"
-        run: poetry run pytest test -m "not heavy"
+        run: poetry run pytest test -m "not heavy" -m "not local"

--- a/infretis/classes/engines/enginebase.py
+++ b/infretis/classes/engines/enginebase.py
@@ -459,7 +459,7 @@ class EngineBase(metaclass=ABCMeta):
             delim: The delimiter used for separation keywords from settings.
 
         Returns:
-         : The settings found in the file.
+            settings: The settings found in the file.
 
         Note:
             This method assumes **only one keyword per line**.
@@ -471,8 +471,7 @@ class EngineBase(metaclass=ABCMeta):
                 key = reg.match(line)
                 if key:
                     keyword_strip = key.group(1).strip()
-                    print('blower', line.split(delim))
-                    settings[keyword_strip] = line.split(delim)[1:]
+                    settings[keyword_strip] = line.split(delim)[1].strip()
         return settings
 
     def execute_command(

--- a/infretis/classes/engines/enginebase.py
+++ b/infretis/classes/engines/enginebase.py
@@ -459,7 +459,7 @@ class EngineBase(metaclass=ABCMeta):
             delim: The delimiter used for separation keywords from settings.
 
         Returns:
-            settings: The settings found in the file.
+         : The settings found in the file.
 
         Note:
             This method assumes **only one keyword per line**.
@@ -471,7 +471,8 @@ class EngineBase(metaclass=ABCMeta):
                 key = reg.match(line)
                 if key:
                     keyword_strip = key.group(1).strip()
-                    settings[keyword_strip] = line.split(delim)[1].strip()
+                    print('blower', line.split(delim))
+                    settings[keyword_strip] = line.split(delim)[1:]
         return settings
 
     def execute_command(

--- a/infretis/classes/engines/engineparts.py
+++ b/infretis/classes/engines/engineparts.py
@@ -464,8 +464,36 @@ class ReadAndProcessOnTheFly:
         if self.file_path[-3:] == ".gz":
             import indexed_gzip as igzip
             self.file_object = igzip.IndexedGzipFile(self.file_path)
+            # The creation of a correct .gz file may require time.
+            # Try to read a line:
+            # try:
+            #     self.file_object.readline()
+            # except:
+            #     #
+            #     return []
             self.file_object.seek(self.current_position)
-            return self.processing_function(self)
+
+            try:
+                return self.processing_function(self)
+            except:
+                # The except error is usually related to igzip, so we
+                # just leave it empty.
+                return []
+
+            # if self.current_position == 0:
+            #     print('cheezeee')
+            # for line in self.file_object:
+            #     print(line)
+
+            # if self.current_position:
+            # try:
+            #     with open(self.file_path, self.read_mode) as _:
+            #         self.file_object.seek(self.current_position)
+            #         print("probe", self.current_position, self.file_path)
+            #         # sleep(0.4)
+            #         return self.processing_function(self)
+            # except FileNotFoundError:
+            #     return []
 
         # we may open at a time where the file
         # is currently not open for reading

--- a/infretis/classes/engines/engineparts.py
+++ b/infretis/classes/engines/engineparts.py
@@ -463,12 +463,13 @@ class ReadAndProcessOnTheFly:
         """Read and process content from a file."""
         # read a zipped file, self.file_object is set in LAMMPS engine already
         print('gere a')
+        import indexed_gzip as igzip
         if self.file_object and self.file_path[-3:] == ".gz":
             print('gere b')
-            # self.file_object = igzip.IndexedGzipFile(self.file_path)
-            # self.file_object.seek(self.current_position)
-            # return self.processing_function(self)
+            self.file_object = igzip.IndexedGzipFile(self.file_path)
             self.file_object.seek(self.current_position)
+            # return self.processing_function(self)
+            # self.file_object.seek(self.current_position)
             return self.processing_function(self)
 
         # we may open at a time where the file
@@ -552,7 +553,6 @@ def lammpstrj_reader(
     coordinate_snapshot = np.zeros(1)
     if reader_class.file_object is None:
         return trajectory, box
-    print('fish', reader_class.file_object.readline)
     for i, line in enumerate(iter(reader_class.file_object.readline, "")):
         spl = line.split()
         if i == 3 and spl:

--- a/infretis/classes/engines/engineparts.py
+++ b/infretis/classes/engines/engineparts.py
@@ -464,36 +464,13 @@ class ReadAndProcessOnTheFly:
         if self.file_path[-3:] == ".gz":
             import indexed_gzip as igzip
             self.file_object = igzip.IndexedGzipFile(self.file_path)
-            # The creation of a correct .gz file may require time.
-            # Try to read a line:
-            # try:
-            #     self.file_object.readline()
-            # except:
-            #     #
-            #     return []
             self.file_object.seek(self.current_position)
-
             try:
                 return self.processing_function(self)
             except:
                 # The except error is usually related to igzip, so we
                 # just leave it empty.
                 return []
-
-            # if self.current_position == 0:
-            #     print('cheezeee')
-            # for line in self.file_object:
-            #     print(line)
-
-            # if self.current_position:
-            # try:
-            #     with open(self.file_path, self.read_mode) as _:
-            #         self.file_object.seek(self.current_position)
-            #         print("probe", self.current_position, self.file_path)
-            #         # sleep(0.4)
-            #         return self.processing_function(self)
-            # except FileNotFoundError:
-            #     return []
 
         # we may open at a time where the file
         # is currently not open for reading

--- a/infretis/classes/engines/engineparts.py
+++ b/infretis/classes/engines/engineparts.py
@@ -6,7 +6,6 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import IO, Any
 import gzip
-import indexed_gzip as igzip
 
 import numpy as np
 
@@ -461,15 +460,11 @@ class ReadAndProcessOnTheFly:
 
     def read_and_process_content(self) -> Any:
         """Read and process content from a file."""
-        # read a zipped file, self.file_object is set in LAMMPS engine already
-        print('gere a')
-        import indexed_gzip as igzip
-        if self.file_object and self.file_path[-3:] == ".gz":
-            print('gere b')
+        # if ".gz", read in an alternative way (curently for LAMMPS)
+        if self.file_path[-3:] == ".gz":
+            import indexed_gzip as igzip
             self.file_object = igzip.IndexedGzipFile(self.file_path)
             self.file_object.seek(self.current_position)
-            # return self.processing_function(self)
-            # self.file_object.seek(self.current_position)
             return self.processing_function(self)
 
         # we may open at a time where the file

--- a/infretis/classes/engines/engineparts.py
+++ b/infretis/classes/engines/engineparts.py
@@ -5,6 +5,8 @@ import os
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import IO, Any
+import gzip
+import indexed_gzip as igzip
 
 import numpy as np
 
@@ -459,6 +461,16 @@ class ReadAndProcessOnTheFly:
 
     def read_and_process_content(self) -> Any:
         """Read and process content from a file."""
+        # read a zipped file, self.file_object is set in LAMMPS engine already
+        print('gere a')
+        if self.file_object and self.file_path[-3:] == ".gz":
+            print('gere b')
+            # self.file_object = igzip.IndexedGzipFile(self.file_path)
+            # self.file_object.seek(self.current_position)
+            # return self.processing_function(self)
+            self.file_object.seek(self.current_position)
+            return self.processing_function(self)
+
         # we may open at a time where the file
         # is currently not open for reading
         try:
@@ -540,6 +552,7 @@ def lammpstrj_reader(
     coordinate_snapshot = np.zeros(1)
     if reader_class.file_object is None:
         return trajectory, box
+    print('fish', reader_class.file_object.readline)
     for i, line in enumerate(iter(reader_class.file_object.readline, "")):
         spl = line.split()
         if i == 3 and spl:

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -363,18 +363,11 @@ class LAMMPSEngine(EngineBase):
                     self.input_files["input"],
                     key="${name}.lammpstrj"
             )
-            msg = "As 'compressed' is set to 'true' in the toml input file,"
             if "${name}.lammpstrj.gz" not in dump_line:
-                msg += (
-                    "'${name}.lammpstrj' in the lammps input file must"
-                    + " be set to '${name}.lammpstrj.gz'. "
+                msg = ("As 'compressed' is set to 'true' in the toml input"
+                    + " file, '${name}.lammpstrj' in the lammps input file"
+                    + " must be set to '${name}.lammpstrj.gz'."
                 )
-            if "custom/gz" not in dump_line:
-                msg += (
-                    "'custom' in the lammps input file must"
-                    + " be set to 'custom/gz'."
-                )
-            if "must" in msg:
                 raise ValueError(msg)
 
         self.atom_style = atom_style
@@ -471,8 +464,9 @@ class LAMMPSEngine(EngineBase):
                     # we may still have some data in the trajectory
                     # so use += here
                     frames = traj_reader.read_and_process_content()
-                    trajectory += frames[0]
-                    box_trajectory += frames[1]
+                    if frames:
+                        trajectory += frames[0]
+                        box_trajectory += frames[1]
                     # loop over the frames that are ready
                     for frame in range(len(trajectory)):
                         posvel = trajectory.pop(0)

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -321,7 +321,7 @@ class LAMMPSEngine(EngineBase):
         timestep: float,
         subcycles: int,
         temperature: float,
-        compressed: bool,
+        compressed: bool = False,
         atom_style: str = "full",
         exe_path: Path = Path(".").resolve(),
         sleep: float = 0.1,
@@ -356,17 +356,24 @@ class LAMMPSEngine(EngineBase):
             "input": self.input_path / "lammps.input",
         }
 
+        dump_line = self._read_input_settings(
+                self.input_files["input"],
+                key="${name}.lammpstrj"
+        )
         self.compressed = compressed
         if self.compressed:
             self.ext += ".gz"
-            dump_line = self._read_input_settings(
-                    self.input_files["input"],
-                    key="${name}.lammpstrj"
-            )
             if "${name}.lammpstrj.gz" not in dump_line:
                 msg = ("As 'compressed' is set to 'true' in the toml input"
                     + " file, '${name}.lammpstrj' in the lammps input file"
                     + " must be set to '${name}.lammpstrj.gz'."
+                )
+                raise ValueError(msg)
+        else:
+            if "${name}.lammpstrj.gz" in dump_line:
+                msg = ("As 'compressed' is set to 'false' in the toml input"
+                    + " file, '${name}.lammpstrj.gz' in the lammps input file"
+                    + " must be set to '${name}.lammpstrj'."
                 )
                 raise ValueError(msg)
 

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -51,7 +51,7 @@ def write_lammpstrj(
         append: If True, the `outfile` will be appended to,
             otherwise, `outfile` will be overwritten.
     """
-    compressed = True if outfile[-3:] == ".gz" else False
+    compressed = True if str(outfile)[-3:] == ".gz" else False
     filemode = "a" if append else "w"
     filemode += "b" if filemode =='w' and compressed else ""
     oopen = open if not compressed else gzip.open

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -103,7 +103,6 @@ def read_lammpstrj(
             (index-based) order calculations are correct.
     """
     block_size = n_atoms + 9
-    print('boing', n_atoms, block_size * frame + 5, infile)
     box = np.genfromtxt(infile, skip_header=block_size * frame + 5, max_rows=3)
     posvel = np.genfromtxt(
         infile, skip_header=block_size * frame + 9, max_rows=n_atoms
@@ -367,7 +366,9 @@ class LAMMPSEngine(EngineBase):
         if self.compressed:
             try:
                 import indexed_gzip as igzip
-                import gzip as igzip
+                import gzip as gzip
+                global gzip, igzip
+                print('botato')
             except ImportError as error:
                 raise ValueError(error)
             dump_line = self._read_input_settings(
@@ -474,7 +475,7 @@ class LAMMPSEngine(EngineBase):
                 # use the igzip package to read trajs if self.compressed
                 print('bro a', self.compressed)
                 if self.compressed:
-                    print('fine')
+                    print('fine', traj_file)
                     traj_reader.file_object = igzip.IndexedGzipFile(traj_file)
                 # start reading on the fly as LAMMPS is still running
                 # if it stops, perform one more iteration to read

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -368,19 +368,24 @@ class LAMMPSEngine(EngineBase):
                 import indexed_gzip as igzip
                 import gzip as gzip
                 global gzip, igzip
-                print('botato')
             except ImportError as error:
                 raise ValueError(error)
             dump_line = self._read_input_settings(
                     self.input_files["input"],
                     key="${name}.lammpstrj"
             )
+            msg = "As 'compressed' is set to 'true' in the toml input file,"
             if "${name}.lammpstrj.gz" not in dump_line:
-                msg = (
-                    "'compressed' is set to 'true' in the toml input file,"
-                    + " so ${name}.lammpstrj in the lammps input file must"
-                    + " be set to ${name}.lammpstrj.gz."
+                msg += (
+                    "'${name}.lammpstrj' in the lammps input file must"
+                    + " be set to '${name}.lammpstrj.gz'. "
                 )
+            if "custom/gz" not in dump_line:
+                msg += (
+                    "'custom' in the lammps input file must"
+                    + " be set to 'custom/gz'."
+                )
+            if "must" in msg:
                 raise ValueError(msg)
         self.ext = "lammpstrj"
         self.ext += ".gz" if self.compressed else ""

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -229,7 +229,7 @@ def check_config(config: dict) -> None:
         if key1 not in config.keys():
             raise TOMLConfigError(f"Engine '{key1}' not defined!")
 
-    # gromacs check
+    # engine checks 2
     for key1 in unique_engines:
         if config[key1]["class"] == "gromacs":
             eng1 = config[key1].copy()
@@ -243,6 +243,24 @@ def check_config(config: dict) -> None:
                         + "al 'input_path'. This would overwrite the"
                         + " settings of one of the engines in"
                         + " 'infretis.mdp'!"
+                    )
+        if config[key1]["class"] == "lammps":
+            if "compressed" not in config[key1]:
+                raise TOMLConfigError(
+                    "'compressed' must be set in the *.toml LAMMPS engine"
+                    + " setting! if False, trajectories will be saved as"
+                    + " lammpstrj text files. If True, compressed lammpstrj.gz"
+                    + " files will be saved instead, but require the optional"
+                    + " python package 'indexed_gzip' to be installed."
+                )
+            if config[key1].get("compressed", False):
+                try:
+                    import indexed_gzip
+                except ImportError as error:
+                    raise TOMLConfigError(
+                        "LAMMPS engine is ran 'compressed=true' but the "
+                        + "indexed_gzip package is not installed! Either"
+                        + " run with 'false' or install the package."
                     )
 
 

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -245,14 +245,6 @@ def check_config(config: dict) -> None:
                         + " 'infretis.mdp'!"
                     )
         if config[key1]["class"] == "lammps":
-            if "compressed" not in config[key1]:
-                raise TOMLConfigError(
-                    "'compressed' must be set in the *.toml LAMMPS engine"
-                    + " setting! if False, trajectories will be saved as"
-                    + " lammpstrj text files. If True, compressed lammpstrj.gz"
-                    + " files will be saved instead, but require the optional"
-                    + " python package 'indexed_gzip' to be installed."
-                )
             if config[key1].get("compressed", False):
                 try:
                     import indexed_gzip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ tomli = "^2.0.1"
 tomli-w = "^1.0.0"
 turtlemd = "^2023.3"
 ase = "^3.20.0"
+indexed-gzip = {version = "^1.9.4", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.0.282"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ infretisrun = "infretis.bin:infretisrun"
 [tool.pytest.ini_options]
 markers = [
     "heavy: mark test as heavy.",
+    "local: mark test as local.",
 ]
 
 [build-system]

--- a/test/engines/check_installed_engine.py
+++ b/test/engines/check_installed_engine.py
@@ -1,0 +1,13 @@
+import shutil
+import sys
+
+def detect_program(programs : list[str]) -> str:
+    # List of possible program names
+
+    for program in programs:
+        # Check if the program exists in the system's PATH
+        if shutil.which(program):
+            return program  # Return the program name for further use
+
+    # return empty string if no programs are found
+    return ""

--- a/test/engines/test_lammps_run.py
+++ b/test/engines/test_lammps_run.py
@@ -1,0 +1,94 @@
+import pathlib
+import pytest
+import tomli
+import shutil
+from distutils.dir_util import copy_tree
+import os
+import filecmp
+
+import numpy as np
+
+import tomli
+import tomli_w
+from check_installed_engine import detect_program
+
+ENGINE = detect_program(["lmp", "lmp_mpi", "lmp_serial"])
+HERE = pathlib.Path(__file__).resolve().parent
+
+@pytest.mark.local
+@pytest.mark.skipif(len(ENGINE) == 0, reason="lammps not installed")
+def test_lammps_sim(tmp_path: pathlib.PosixPath) -> None:
+    """Check that we get the same results between
+    compressed and uncompressed lammps."""
+
+    h2_stuff = HERE / "../../examples/lammps/H2/"
+    h2_init = HERE / "../../infretis/tools/generate_H2_loadpaths.py"
+    folder = tmp_path / "lmp"
+    folder.mkdir()
+    copy_tree(h2_stuff, str(folder) +'/')
+    shutil.copy(h2_init, str(folder) +'/')
+    os.chdir(folder)
+
+    # read .toml and change som options
+    with open("infretis.toml", "rb") as rfile:
+        config = tomli.load(rfile)
+    config["engine"]["lmp"] = ENGINE
+
+    # for generate_H2_loadpaths
+    with open("infretis.toml", "wb") as f:
+        tomli_w.dump(config, f)
+
+    config["engine"]["compressed"] = False
+    config["runner"]["workers"] = 1
+    config["simulation"]["steps"] = 10
+    config["simulation"]["load_dir"] = "load_un"
+
+    with open("infretis_un.toml", "wb") as f:
+        tomli_w.dump(config, f)
+
+    config["engine"]["compressed"] = True
+    config["simulation"]["load_dir"] = "load_co"
+    with open("infretis_co.toml", "wb") as f:
+        tomli_w.dump(config, f)
+
+    # get initial paths
+    python = detect_program(["python", "python3"])
+    success = os.system(f"{python} generate_H2_loadpaths.py")
+    assert success == 0
+
+    # import infretis.tools.generate_H2_loadpaths
+
+    copy_tree("temporary_load", "load_un")
+    copy_tree("temporary_load", "load_co")
+
+    success = os.system("infretisrun -i infretis_un.toml >| out.txt")
+    assert success == 0
+    success = os.system("sed -i 's/lammpstrj/lammpstrj.gz/g' lammps_input/lammps.input")
+    assert success == 0
+    success = os.system("infretisrun -i infretis_co.toml >| out.txt")
+    assert success == 0
+
+    assert filecmp.cmp("infretis_data_1.txt", "infretis_data_2.txt")
+
+    for pn in os.listdir("load_un"):
+        if int(pn) < 10:
+            continue
+        assert filecmp.cmp(f"load_un/{pn}/order.txt", f"load_co/{pn}/order.txt")
+        assert filecmp.cmp(f"load_un/{pn}/energy.txt", f"load_co/{pn}/energy.txt")
+
+        # co trajectories have additional ".gz" endings
+        data_un = np.loadtxt(f"load_un/{pn}/traj.txt", dtype="str")
+        data_co = np.loadtxt(f"load_co/{pn}/traj.txt", dtype="str")
+        assert (data_un[:, 0] == data_co[:, 0]).all()
+        assert (data_un[:, 2] == data_co[:, 2]).all()
+        assert (data_un[:, 3] == data_co[:, 3]).all()
+
+        # add .gz
+        data_un_gz = np.array([i + ".gz" for i in data_un[:, 1]])
+        assert (data_un_gz == data_co[:, 1]).all()
+
+        # check if files are there
+        for file in set(data_un[:, 1]):
+            os.path.isfile(f"load_un/{pn}/accepted/{file}")
+        for file in set(data_co[:, 1]):
+            os.path.isfile(f"load_co/{pn}/accepted/{file}")

--- a/test/engines/test_lammps_run.py
+++ b/test/engines/test_lammps_run.py
@@ -56,8 +56,6 @@ def test_lammps_sim(tmp_path: pathlib.PosixPath) -> None:
     success = os.system(f"{python} generate_H2_loadpaths.py")
     assert success == 0
 
-    # import infretis.tools.generate_H2_loadpaths
-
     copy_tree("temporary_load", "load_un")
     copy_tree("temporary_load", "load_co")
 
@@ -89,6 +87,6 @@ def test_lammps_sim(tmp_path: pathlib.PosixPath) -> None:
 
         # check if files are there
         for file in set(data_un[:, 1]):
-            os.path.isfile(f"load_un/{pn}/accepted/{file}")
+            assert os.path.isfile(f"load_un/{pn}/accepted/{file}")
         for file in set(data_co[:, 1]):
-            os.path.isfile(f"load_co/{pn}/accepted/{file}")
+            assert os.path.isfile(f"load_co/{pn}/accepted/{file}")


### PR DESCRIPTION
Add option to run lammps engine with .gz compressed trajectories. This means that the trajectories are ~2.5x to ~3x smaller than standard text files. Things to note:

* Optional dependency indexed-gzip is added for reading compressed data streams.
* Since we're technically "cancelling" lammps runs once an interface is hit, the actually the gzip trajectories are not saved "correctly", in the sense that the last "end of file" line is not written (by lammps). This means that the trajectories cannot be opened by vim directly, but they can be opened and read via gzip (that throws an error after the last line has been read). But it seems to not be a problem for infretis simulations, as shown by the included test.