### PR TITLE
add .wfn save feature for cp2k simulations

### DIFF
--- a/infretis/classes/engines/cp2k.py
+++ b/infretis/classes/engines/cp2k.py
@@ -588,7 +588,6 @@ def write_for_run_vel(
     name: str = "md_step",
     restart_wfn: str = "doesnotexist.wfn",
     print_freq: Optional[int] = None,
-
 ) -> None:
     """Create input file to perform n steps.
 
@@ -636,8 +635,8 @@ def write_for_run_vel(
             "data": ["BACKUP_COPIES 0"],
             "replace": True,
         },
-        'FORCE_EVAL->DFT': {
-            'data': {'WFN_RESTART_FILE_NAME': restart_wfn},
+        "FORCE_EVAL->DFT": {
+            "data": {"WFN_RESTART_FILE_NAME": restart_wfn},
         },
     }
     for veli in vel:


### PR DESCRIPTION
Right now, starting MD with CP2K will cause the initial frame to guess the WFN with **atomic guess**, which may require much more time for SCF convergence than the sequential MD steps that intrinsically utilizes the previous calculated WFN. 

Here I implement a "stupid" way to save and utilize calculated WFNs ensemble-wise by saving the last WFN into the engine input_path folder. Ideally we would save one wfn into the load/path_number/, but that is not accessable from the `_propagate_from` function in `infretis/classes/engines/cp2k.py` so more modifications would be required for path-wise wfn functionality.