### PR TITLE
use infretis seed

### DIFF
--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -68,7 +68,7 @@ class REPEX_state:
         if "restarted_from" in config["current"]:
             self.set_rgen()
         else:
-            self.rgen = default_rng(seed=config.get("seed", 0))
+            self.rgen = default_rng(seed=config["simulation"]["seed"])
 
         n = config["current"]["size"]
         if minus:

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -167,6 +167,9 @@ def setup_config(
         config["simulation"]["ensemble_engines"] = ens_engs
 
     # set the keywords once
+    if "seed" not in config["simulation"].keys():
+        config["simulation"]["seed"] = 0
+
     quantis = config["simulation"]["tis_set"].get("quantis", False)
     config["simulation"]["tis_set"]["quantis"] = quantis
 

--- a/test/permanents/test_permanents.py
+++ b/test/permanents/test_permanents.py
@@ -55,7 +55,13 @@ PERMANENT2 = 10508395762604.0
 
 def test_matrix1():
     """Test ..."""
-    state = REPEX_state({"current": {"size": 1}, "runner": {"workers": 1}})
+    state = REPEX_state(
+        {
+            "current": {"size": 1},
+            "runner": {"workers": 1},
+            "simulation": {"seed": 0},
+        }
+    )
     p_matrix = state.permanent_prob(W_MATRIX1)
     permanent = state.fast_glynn_perm(W_MATRIX1)
     assert pytest.approx(p_matrix) == P_MATRIX1
@@ -64,7 +70,13 @@ def test_matrix1():
 
 def test_matrix2():
     """Test ..."""
-    state = REPEX_state({"current": {"size": 1}, "runner": {"workers": 1}})
+    state = REPEX_state(
+        {
+            "current": {"size": 1},
+            "runner": {"workers": 1},
+            "simulation": {"seed": 0},
+        }
+    )
     p_matrix = state.permanent_prob(W_MATRIX2)
     permanent = state.fast_glynn_perm(W_MATRIX2)
     assert pytest.approx(p_matrix) == P_MATRIX2

--- a/test/repex/test_repex.py
+++ b/test/repex/test_repex.py
@@ -11,7 +11,7 @@ def test_rgen_io(tmp_path: PosixPath) -> None:
         {
             "current": {"size": 1, "cstep": 0},
             "runner": {"workers": 1},
-            "simulation": {},
+            "simulation": {"seed": 0},
         }
     )
     folder = tmp_path / "temp"


### PR DESCRIPTION
We didn't actually use the infretis seed specified in the `simulation` section of the .toml. The seed is now set in `setup_config()`, such that its also written to the restart.toml file.