### PR TITLE
add option 'keep_maxop_trajs' in [output]

### DIFF
--- a/examples/ase/H2/infretis0.toml
+++ b/examples/ase/H2/infretis0.toml
@@ -1,7 +1,7 @@
 [infinit]
 pL = 0.3
 steps_per_iter = [20,40,80,160,320]
-nskip = 10
+skip = 0.1
 cstep = -1
 initial_conf = "conf.traj"
 lamres = 0.005

--- a/examples/turtlemd/H2_quantis/infretis.toml
+++ b/examples/turtlemd/H2_quantis/infretis.toml
@@ -6,7 +6,7 @@ wmdrun = ["0","0"]
 
 [simulation]
 interfaces = [0.345, 0.4915, 1.200]
-steps = 2
+steps = 20
 seed = 1
 load_dir = 'load'
 shooting_moves = ['sh', 'sh', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf', 'wf']
@@ -19,6 +19,7 @@ n_jumps = 3
 interface_cap = 0.54
 quantis = true
 
+# engine [0-]
 [engine0]
 class = 'turtlemd'
 engine = 'turtlemd'
@@ -34,9 +35,9 @@ gamma = 10
 beta = 0.4009078751268027 # 1/(boltzmann*T)
 
 [engine0.potential]
-class = 'LennardJones'
+class = 'DoubleWellPair'
 [engine0.potential.settings]
-parameters = {1={"sigma"=0.3, "epsilon"= 25.0, "rcut"= 1.2}}
+parameters = {"rzero"=0.3367, "height"= 25.0, "width"= 0.13}
 
 [engine0.particles]
 mass = [1.008, 1.008]
@@ -48,7 +49,6 @@ periodic = [true, true, true]
 low = [0, 0, 0]
 high = [3, 3, 3]
 
-# engine [N+]
 [engine]
 class = 'turtlemd'
 engine = 'turtlemd'
@@ -64,9 +64,9 @@ gamma = 10
 beta = 0.4009078751268027 # 1/(boltzmann*T)
 
 [engine.potential]
-class = 'DoubleWellPair'
+class = 'LennardJones'
 [engine.potential.settings]
-parameters = {"rzero"=0.3367, "height"= 25.0, "width"= 0.13}
+parameters = {1={"sigma"=0.3, "epsilon"= 25.0, "rcut"= 1.2}}
 
 [engine.particles]
 mass = [1.008, 1.008]

--- a/infretis/classes/engines/enginebase.py
+++ b/infretis/classes/engines/enginebase.py
@@ -369,10 +369,10 @@ class EngineBase(metaclass=ABCMeta):
     def snapshot_to_system(system: System, snapshot: Dict[str, Any]) -> System:
         """Convert a snapshot to a system object."""
         system_copy = system.copy()
-        system_copy.order = snapshot.get("order", None)
+        system_copy.order = snapshot.get("order", [-float("nan")])
         # # particles = system_copy.particles
-        system_copy.pos = snapshot.get("pos", None)
-        system_copy.vel = snapshot.get("vel", None)
+        system_copy.pos = snapshot.get("pos", np.zeros(0))
+        system_copy.vel = snapshot.get("vel", np.zeros(0))
         system_copy.vpot = snapshot.get("vpot", None)
         system_copy.ekin = snapshot.get("ekin", None)
         for external in ("config", "vel_rev"):

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -166,12 +166,13 @@ class REPEX_state:
     @property
     def maxop(self):
         """Get the maximum orderparameter seen during the simulation."""
-        return self.config["current"]["maxop"]
+        return self.config["current"].get("maxop",-float("inf"))
 
     @maxop.setter
     def maxop(self, val):
-        """Update the maximum orderpameter seen druing the sumulation."""
-        self.config["current"]["maxop"] = val
+        """Update the maximum orderpameter seen during the sumulation."""
+        if self.config["output"]["keep_maxop_trajs"]:
+            self.config["current"]["maxop"] = val
 
     def pick(self):
         """Pick path and ens."""

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -906,9 +906,6 @@ class REPEX_state:
         for ens_num in picked.keys():
             pn_old = picked[ens_num]["pn_old"]
             out_traj = picked[ens_num]["traj"]
-            # keep track of the highest order value seen during the sim
-            if ens_num != -1 and out_traj.ordermax[0] > self.maxop:
-                self.maxop = out_traj.ordermax[0]
             self.ensembles[ens_num + 1] = picked[ens_num]["ens"]
 
             for idx, lock in enumerate(self.locked):
@@ -916,6 +913,9 @@ class REPEX_state:
                     self.locked.pop(idx)
             # if path is new: number and save the path:
             if out_traj.path_number is None or md_items["status"] == "ACC":
+                # keep track of the highest order value seen during the sim
+                if ens_num != -1 and out_traj.ordermax[0] > self.maxop:
+                    self.maxop = out_traj.ordermax[0]
                 # move to accept:
                 ens_save_idx = self.traj_data[pn_old]["ens_save_idx"]
                 out_traj.path_number = traj_num

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -166,7 +166,7 @@ class REPEX_state:
     @property
     def maxop(self):
         """Get the maximum orderparameter seen during the simulation."""
-        return self.config["current"].get("maxop",-float("inf"))
+        return self.config["current"].get("maxop", -float("inf"))
 
     @maxop.setter
     def maxop(self, val):

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -1305,7 +1305,7 @@ def quantis_swap_zero(
     )
 
     # finished with path1, now do some extra checks
-    if new_path1.length == maxlen1 and new_path1.get_end_point:
+    if new_path1.length >= maxlen1:
         new_path1.status = "FTX"
     elif new_path1.length < 3:
         new_path1.status = "FTS"

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -175,6 +175,16 @@ def setup_config(
     # [output]
     keep_maxop_trajs = config["output"].get("keep_maxop_trajs", False)
     config["output"]["keep_maxop_trajs"] = keep_maxop_trajs
+    delete_old = config["output"].get("delete_old", False)
+    delete_old_all = config["output"].get("delete_old_all", False)
+    if not delete_old and keep_maxop_trajs:
+        raise TOMLConfigError("keep_maxop_trajs=True requires delete_old=True")
+    if delete_old_all and keep_maxop_trajs:
+        msg = (
+            "delete_old_all=True will delete all trajectories. Set "
+            "keep_maxop_trajs to False in the [output] section"
+            )
+        raise TOMLConfigError(msg)
 
     quantis = config["simulation"]["tis_set"].get("quantis", False)
     config["simulation"]["tis_set"]["quantis"] = quantis

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -167,9 +167,14 @@ def setup_config(
             ens_engs.append(["engine"])
         config["simulation"]["ensemble_engines"] = ens_engs
 
-    # set the keywords once
+    # set all keywords only once, so they appear in restart.toml
+    # and we can avoid the .get() in other parts
     if "seed" not in config["simulation"].keys():
         config["simulation"]["seed"] = 0
+
+    # [output]
+    keep_maxop_trajs = config["output"].get("keep_maxop_trajs", False)
+    config["output"]["keep_maxop_trajs"] = keep_maxop_trajs
 
     quantis = config["simulation"]["tis_set"].get("quantis", False)
     config["simulation"]["tis_set"]["quantis"] = quantis

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -149,6 +149,7 @@ def setup_config(
             "locked": [],
             "size": size,
             "frac": {},
+            "maxop": -float("inf"),
         }
 
         # write/overwrite infretis_data.txt

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -149,7 +149,6 @@ def setup_config(
             "locked": [],
             "size": size,
             "frac": {},
-            "maxop": -float("inf"),
         }
 
         # write/overwrite infretis_data.txt

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -182,7 +182,7 @@ def setup_config(
         msg = (
             "delete_old_all=True will delete all trajectories. Set "
             "keep_maxop_trajs to False in the [output] section"
-            )
+        )
         raise TOMLConfigError(msg)
 
     quantis = config["simulation"]["tis_set"].get("quantis", False)

--- a/infretis/tools/generate_H2_loadpaths.py
+++ b/infretis/tools/generate_H2_loadpaths.py
@@ -52,14 +52,12 @@ def create_initial_paths():
     config = setup_config()
     state = REPEX_state(config, minus=True)
     state.initiate_ensembles()
-    if "engine0" in config.keys():
-        config["engine"] = config["engine1"].copy()
     engine: EngineBase = create_engine(config)
     engine.order_function = create_orderparameter(config)
     interfaces = np.array(config["simulation"]["interfaces"])
     # the initial configurations for each ensemble are given by the
     # interface location + (interface1 - interface0)/100
-    delta = (interfaces[1] - interfaces[0]) / 100
+    delta = (interfaces[1] - interfaces[0]) / 10
     distances = interfaces * 1
     distances[1:] = distances[:-1] + delta
     distances[0] -= delta

--- a/test/simulations/data/10steps_wf/restart.toml
+++ b/test/simulations/data/10steps_wf/restart.toml
@@ -133,6 +133,7 @@ delete_old = true
 delete_old_all = true
 data_file = "./infretis_data.txt"
 pattern_file = "pattern.txt"
+keep_maxop_trajs = false
 
 [current]
 traj_num = 19

--- a/test/simulations/data/20steps_wf/restart.toml
+++ b/test/simulations/data/20steps_wf/restart.toml
@@ -133,6 +133,7 @@ delete_old = true
 delete_old_all = true
 data_file = "./infretis_data.txt"
 pattern_file = "pattern.txt"
+keep_maxop_trajs = false
 
 [current]
 traj_num = 30

--- a/test/simulations/data/30steps_wf/restart.toml
+++ b/test/simulations/data/30steps_wf/restart.toml
@@ -133,6 +133,7 @@ delete_old = true
 delete_old_all = true
 data_file = "./infretis_data.txt"
 pattern_file = "pattern.txt"
+keep_maxop_trajs = false
 
 [current]
 traj_num = 40


### PR DESCRIPTION
The `keep_maxop_trajs` will be handy with infinit to reduce directory sizes.

If `delete_old=True` and `keep_maxop_trajs=True`, we delete old trajectories as usual, except trajectories corresponding to the path with the maximum seen orderparameter value up til now. It stores the order parameter value as `maxop` in the [current] section in the config/restart.toml.

This essentially stores all trajectory files of paths that *have been* the highest scoring order parameter path during a simulation. So these will not be deleted, even if they no longer are the highest scoring paths.


* also fixes the `H2_quantis` example