### PR TITLE
infretis/classes/engines/cp2k.py

### DIFF
--- a/infretis/classes/engines/cp2k.py
+++ b/infretis/classes/engines/cp2k.py
@@ -1081,3 +1081,22 @@ class CP2KEngine(EngineBase):
         else:
             dek = kin_new - kin_old
         return dek, kin_new
+
+
+    def run_cp2k(self, input_file, proj_name):
+        """
+        Run the CP2K executable.
+
+        Returns
+        -------
+        out : dict
+            The files created by the run.
+
+        """
+        cmd = self.cp2k + ['-i', input_file]
+        logger.debug('Executing CP2K %s: %s', proj_name, input_file)
+        self.execute_command(cmd, cwd=self.exe_dir, inputs=None)
+        out = {}
+        for key, name in OUTPUT_FILES.items():
+            out[key] = os.path.join(self.exe_dir, name.format(proj_name))
+        return out

--- a/infretis/classes/engines/cp2k.py
+++ b/infretis/classes/engines/cp2k.py
@@ -1082,7 +1082,6 @@ class CP2KEngine(EngineBase):
             dek = kin_new - kin_old
         return dek, kin_new
 
-
     def run_cp2k(self, input_file, proj_name):
         """
         Run the CP2K executable.
@@ -1093,8 +1092,8 @@ class CP2KEngine(EngineBase):
             The files created by the run.
 
         """
-        cmd = self.cp2k + ['-i', input_file]
-        logger.debug('Executing CP2K %s: %s', proj_name, input_file)
+        cmd = self.cp2k + ["-i", input_file]
+        logger.debug("Executing CP2K %s: %s", proj_name, input_file)
         self.execute_command(cmd, cwd=self.exe_dir, inputs=None)
         out = {}
         for key, name in OUTPUT_FILES.items():


### PR DESCRIPTION
Add a deleted feature for the `cp2k.py` engine. Namely, the `run_cp2k` function. Together with e.g. `write_for_run_vel`, the functions in `cp2k.py` can be imported and launched to do individual SCF calculations. This is important for order parameters that depend on e.g. electron orbitals.