### PR TITLE
add infretis_data.tar feature

### DIFF
--- a/infretis/classes/engines/ams.py
+++ b/infretis/classes/engines/ams.py
@@ -10,6 +10,7 @@ Important classes defined here
 AMSEngine (:py:class:`.AMSEngine`)
     A class responsible for interfacing AMS.
 """
+
 import copy
 import logging
 import os

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -229,7 +229,7 @@ def get_atom_masses(lammps_data: Union[str, Path], atom_style) -> np.ndarray:
         raise NotImplementedError(f"Style {atom_style}' not supported yet.")
     n_atoms = 0
     n_atom_types = 0
-    atom_type_masses = np.zeros(0)
+    atom_type_masses = np.zeros((1, 2))
     atoms = np.zeros(0)
     with open(lammps_data) as readfile:
         for i, line in enumerate(readfile):

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -59,8 +59,7 @@ def write_lammpstrj(
     with open(outfile, filemode) as writefile:
         to_write = (
             f"ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n{pos.shape[0]}\n\
-ITEM: BOX BOUNDS {box_header}pp pp pp\n"
-            ""
+ITEM: BOX BOUNDS {box_header}pp pp pp\n" ""
         )
 
         if box is not None:
@@ -256,10 +255,8 @@ def get_atom_masses(lammps_data: Union[str, Path], atom_style) -> np.ndarray:
                 atoms = atoms[idx]
     # if we did not find all of the information
     if n_atoms == 0 or n_atom_types == 0:
-        raise ValueError(
-            f"Could not read atom masses from {lammps_data}. \
-                         Found {n_atoms} atoms and {n_atom_types} atom_types."
-        )
+        raise ValueError(f"Could not read atom masses from {lammps_data}. \
+                         Found {n_atoms} atoms and {n_atom_types} atom_types.")
     masses = np.zeros((n_atoms, 1))
     for atom_type in range(1, n_atom_types + 1):
         idx = np.where(atoms[:, col[atom_style]] == atom_type)[0]

--- a/infretis/classes/formatter.py
+++ b/infretis/classes/formatter.py
@@ -369,19 +369,6 @@ class OutputBase(metaclass=ABCMeta):
         self.formatter = formatter
         self.first_write = True
 
-    def output(self, step: int, data: List[Any]) -> Any:
-        """Use the formatter to write data to the file.
-
-        Args:
-            step: The current step number.
-            data: The data we are going to format and write.
-        """
-        if self.first_write and self.formatter.print_header:
-            self.first_write = False
-            self.write(self.formatter.header)
-        for line in self.formatter.format(step, data):
-            self.write(line)
-
     @abstractmethod
     def write(self, towrite: str, end: str = "\n") -> bool:
         """Write a string to the output defined by this class.
@@ -563,12 +550,6 @@ class FileIO(OutputBase):
         if self.fileh is not None and not self.fileh.closed:
             self.fileh.flush()
             os.fsync(self.fileh.fileno())
-
-    def output(self, step: int, data: List[Any]) -> Any:
-        """Open file before first write."""
-        if self.first_write:
-            self.open()
-        return super().output(step, data)
 
     def __del__(self) -> None:
         """Close the file in case the object is deleted."""

--- a/infretis/classes/path.py
+++ b/infretis/classes/path.py
@@ -152,7 +152,7 @@ class Path:
         idx = rgen.integers(1, self.length - 1)
         order = self.phasepoints[idx].order[0]
         logger.debug(f"Selected point with orderp {order}")
-        return self.phasepoints[idx], idx
+        return self.phasepoints[idx], int(idx)
 
     def append(self, phasepoint: System) -> bool:
         """Append a new phase point to the path."""

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -2,9 +2,9 @@
 
 import logging
 import os
+import tarfile
 import time
 from datetime import datetime
-import tarfile
 
 import numpy as np
 import tomli_w
@@ -918,9 +918,7 @@ class REPEX_state:
                 load_dir = self.config["simulation"]["load_dir"]
                 data = {
                     "path": out_traj,
-                    "dir": os.path.join(
-                        os.getcwd(), load_dir
-                    ),
+                    "dir": os.path.join(os.getcwd(), load_dir),
                 }
                 out_traj = self.pstore.output(self.cstep, data)
 
@@ -928,7 +926,9 @@ class REPEX_state:
                 with tarfile.open(self.tar_file, "a") as tar:
                     for txt in ["order.txt", "energy.txt", "traj.txt"]:
                         txt_dir = os.path.join(data["dir"], str(traj_num), txt)
-                        tar.add(txt_dir, arcname=f"{load_dir}/{traj_num}/order.txt")
+                        tar.add(
+                            txt_dir, arcname=f"{load_dir}/{traj_num}/order.txt"
+                        )
 
                 self.traj_data[traj_num] = {
                     "frac": np.zeros(self.n, dtype="longdouble"),
@@ -968,7 +968,9 @@ class REPEX_state:
                                 )
                                 if os.path.isfile(txt_adress):
                                     os.remove(txt_adress)
-                            accepted = os.path.join(load_dir, pn_old_del, "accepted")
+                            accepted = os.path.join(
+                                load_dir, pn_old_del, "accepted"
+                            )
                             if not os.listdir(accepted):
                                 os.rmdir(accepted)
                             pathfolder = os.path.join(load_dir, pn_old_del)

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -81,6 +81,7 @@ class REPEX_state:
         self._random_count = 0
         self._trajs = [""] * n
         self.zeroswap = 0.5
+        self.tar = None
 
         # detect any locked ens-path pairs exist pre start
         self.locked0 = list(self.config["current"].get("locked", []))
@@ -156,6 +157,11 @@ class REPEX_state:
     def maxop(self):
         """Get the maximum orderparameter seen during the simulation."""
         return self.config["current"].get("maxop", -float("inf"))
+
+    @property
+    def tar_file(self):
+        """Retrieve total steps from config dict."""
+        return self.config["output"]["tar_file"]
 
     @maxop.setter
     def maxop(self, val):
@@ -916,6 +922,12 @@ class REPEX_state:
                     ),
                 }
                 out_traj = self.pstore.output(self.cstep, data)
+
+                # save to tar file
+                for txt in ["order.txt", "energy.txt", "traj.txt"]:
+                    txt_dir = os.path.join(data["dir"], str(traj_num), txt)
+                    self.tar.add(txt_dir)
+
                 self.traj_data[traj_num] = {
                     "frac": np.zeros(self.n, dtype="longdouble"),
                     "max_op": out_traj.ordermax,
@@ -967,6 +979,7 @@ class REPEX_state:
                             "adress": self.traj_data[pn_old]["adress"],
                             "max_op": self.traj_data[pn_old]["max_op"],
                         }
+
             pn_news.append(out_traj.path_number)
             self.add_traj(ens_num, out_traj, valid=out_traj.weights)
 

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -154,20 +154,20 @@ class REPEX_state:
         return self.config["runner"]["workers"]
 
     @property
-    def maxop(self):
+    def maxop(self) -> float:
         """Get the maximum orderparameter seen during the simulation."""
         return self.config["current"].get("maxop", -float("inf"))
+
+    @maxop.setter
+    def maxop(self, val: float) -> None:
+        """Update the maximum orderpameter seen during the sumulation."""
+        if self.config["output"]["keep_maxop_trajs"]:
+            self.config["current"]["maxop"] = val
 
     @property
     def tar_file(self):
         """Retrieve total steps from config dict."""
         return self.config["output"]["tar_file"]
-
-    @maxop.setter
-    def maxop(self, val):
-        """Update the maximum orderpameter seen during the sumulation."""
-        if self.config["output"]["keep_maxop_trajs"]:
-            self.config["current"]["maxop"] = val
 
     def pick(self):
         """Pick path and ens."""

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -4,6 +4,7 @@ import logging
 import os
 import time
 from datetime import datetime
+import tarfile
 
 import numpy as np
 import tomli_w
@@ -81,7 +82,6 @@ class REPEX_state:
         self._random_count = 0
         self._trajs = [""] * n
         self.zeroswap = 0.5
-        self.tar = None
 
         # detect any locked ens-path pairs exist pre start
         self.locked0 = list(self.config["current"].get("locked", []))
@@ -915,18 +915,20 @@ class REPEX_state:
                 # move to accept:
                 ens_save_idx = self.traj_data[pn_old]["ens_save_idx"]
                 out_traj.path_number = traj_num
+                load_dir = self.config["simulation"]["load_dir"]
                 data = {
                     "path": out_traj,
                     "dir": os.path.join(
-                        os.getcwd(), self.config["simulation"]["load_dir"]
+                        os.getcwd(), load_dir
                     ),
                 }
                 out_traj = self.pstore.output(self.cstep, data)
 
                 # save to tar file
-                for txt in ["order.txt", "energy.txt", "traj.txt"]:
-                    txt_dir = os.path.join(data["dir"], str(traj_num), txt)
-                    self.tar.add(txt_dir)
+                with tarfile.open(self.tar_file, "a") as tar:
+                    for txt in ["order.txt", "energy.txt", "traj.txt"]:
+                        txt_dir = os.path.join(data["dir"], str(traj_num), txt)
+                        tar.add(txt_dir, arcname=f"{load_dir}/{traj_num}/order.txt")
 
                 self.traj_data[traj_num] = {
                     "frac": np.zeros(self.n, dtype="longdouble"),
@@ -944,7 +946,6 @@ class REPEX_state:
                 ):
                     if len(self.pn_olds) > self.n - 2:
                         pn_old_del, del_dic = next(iter(self.pn_olds.items()))
-                        load_dir = self.config["simulation"]["load_dir"]
                         if self.config["output"]["keep_maxop_trajs"]:
                             path_dir = os.path.join(load_dir, pn_old_del)
                             # delete trajectory files if low orderp (infinit)
@@ -967,10 +968,12 @@ class REPEX_state:
                                 )
                                 if os.path.isfile(txt_adress):
                                     os.remove(txt_adress)
-                            os.rmdir(
-                                os.path.join(load_dir, pn_old_del, "accepted")
-                            )
-                            os.rmdir(os.path.join(load_dir, pn_old_del))
+                            accepted = os.path.join(load_dir, pn_old_del, "accepted")
+                            if not os.listdir(accepted):
+                                os.rmdir(accepted)
+                            pathfolder = os.path.join(load_dir, pn_old_del)
+                            if not os.listdir(pathfolder):
+                                os.rmdir(pathfolder)
                         # pop the deleted path.
                         self.pn_olds.pop(pn_old_del)
                     # keep delete list:

--- a/infretis/scheduler.py
+++ b/infretis/scheduler.py
@@ -23,23 +23,20 @@ def scheduler(config):
         futures.add(runner.submit_work(worker_md_items))
 
     # main step loop
-    with tarfile.open(state.tar_file, "a") as tar:
-        state.tar = tar
-        while state.loop():
-            # Get futures as they are completed
-            future = futures.as_completed()
+    while state.loop():
+        # Get futures as they are completed
+        future = futures.as_completed()
 
-            if future:
-                worker_md_items = state.treat_output(future.result())
+        if future:
+            worker_md_items = state.treat_output(future.result())
 
-            # submit new job
-            if state.cstep + state.workers <= state.tsteps:
-                # chose ens and path for the next job
-                worker_md_items = state.prep_md_items(worker_md_items)
+        # submit new job
+        if state.cstep + state.workers <= state.tsteps:
+            # chose ens and path for the next job
+            worker_md_items = state.prep_md_items(worker_md_items)
 
-                # submit job to scheduler
-                futures.add(runner.submit_work(worker_md_items))
+            # submit job to scheduler
+            futures.add(runner.submit_work(worker_md_items))
 
     # end client
-    state.tar = None
     runner.stop()

--- a/infretis/scheduler.py
+++ b/infretis/scheduler.py
@@ -1,6 +1,7 @@
 """The main infretis loop."""
 
 import copy
+import tarfile
 
 from infretis.setup import setup_internal, setup_runner
 
@@ -22,20 +23,23 @@ def scheduler(config):
         futures.add(runner.submit_work(worker_md_items))
 
     # main step loop
-    while state.loop():
-        # Get futures as they are completed
-        future = futures.as_completed()
+    with tarfile.open(state.tar_file, "a") as tar:
+        state.tar = tar
+        while state.loop():
+            # Get futures as they are completed
+            future = futures.as_completed()
 
-        if future:
-            worker_md_items = state.treat_output(future.result())
+            if future:
+                worker_md_items = state.treat_output(future.result())
 
-        # submit new job
-        if state.cstep + state.workers <= state.tsteps:
-            # chose ens and path for the next job
-            worker_md_items = state.prep_md_items(worker_md_items)
+            # submit new job
+            if state.cstep + state.workers <= state.tsteps:
+                # chose ens and path for the next job
+                worker_md_items = state.prep_md_items(worker_md_items)
 
-            # submit job to scheduler
-            futures.add(runner.submit_work(worker_md_items))
+                # submit job to scheduler
+                futures.add(runner.submit_work(worker_md_items))
 
     # end client
+    state.tar = None
     runner.stop()

--- a/infretis/scheduler.py
+++ b/infretis/scheduler.py
@@ -1,7 +1,6 @@
 """The main infretis loop."""
 
 import copy
-import tarfile
 
 from infretis.setup import setup_internal, setup_runner
 

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import tarfile
 from typing import Optional, Tuple
 
 import tomli
@@ -273,11 +274,12 @@ def check_config(config: dict) -> None:
 
 
 def write_header(config: dict) -> None:
-    """Write infretis_data.txt header.
+    """Write infretis_data.txt/tar.
 
     Args
         config: the configuration dictionary
     """
+    # prep infretis_data.txt
     size = config["current"]["size"]
     data_dir = config["output"]["data_dir"]
     data_file = os.path.join(data_dir, "infretis_data.txt")
@@ -293,6 +295,18 @@ def write_header(config: dict) -> None:
         ens_str = "\t".join([f"{i:03.0f}" for i in range(size)])
         write.write("# " + f"\txxx\tlen\tmax OP\t\t{ens_str}\n")
         write.write("# " + "=" * (34 + 8 * size) + "\n")
+
+    # prep infretis_data.tar
+    tar_file = os.path.join(data_dir, "infretis_data.tar")
+    if os.path.isfile(tar_file):
+        for i in range(1, 1000):
+            tar_file = os.path.join(data_dir, f"infretis_data_{i}.tar")
+            if not os.path.isfile(tar_file):
+                break
+
+    config["output"]["tar_file"] = tar_file
+    with tarfile.open(tar_file, mode="w"):
+        pass
 
 
 def setup_logger(inp: str = "sim.log") -> None:

--- a/test/simulations/data/10steps_wf/restart.toml
+++ b/test/simulations/data/10steps_wf/restart.toml
@@ -132,6 +132,7 @@ pattern = 1
 delete_old = true
 delete_old_all = true
 data_file = "./infretis_data.txt"
+tar_file = "./infretis_data.tar"
 keep_maxop_trajs = false
 
 [current]

--- a/test/simulations/data/20steps_wf/restart.toml
+++ b/test/simulations/data/20steps_wf/restart.toml
@@ -132,6 +132,7 @@ pattern = 1
 delete_old = true
 delete_old_all = true
 data_file = "./infretis_data.txt"
+tar_file = "./infretis_data.tar"
 keep_maxop_trajs = false
 
 [current]

--- a/test/simulations/data/30steps_wf/restart.toml
+++ b/test/simulations/data/30steps_wf/restart.toml
@@ -132,6 +132,7 @@ pattern = 1
 delete_old = true
 delete_old_all = true
 data_file = "./infretis_data.txt"
+tar_file = "./infretis_data.tar"
 keep_maxop_trajs = false
 
 [current]

--- a/test/simulations/test_run_infretis.py
+++ b/test/simulations/test_run_infretis.py
@@ -135,6 +135,7 @@ def test_run_airetis_wf(tmp_path: PosixPath) -> None:
     with open("restart.toml", mode="rb") as f:
         config = tomli.load(f)
         config["output"]["data_file"] = "./infretis_data.txt"
+        config["output"]["tar_file"] = "./infretis_data.tar"
         config["output"]["delete_old_all"] = True
     with open("restart.toml", "wb") as f:
         tomli_w.dump(config, f)


### PR DESCRIPTION
Add simple infretis_data.tar feature, where by default we append new *txt files into infretis_data.tar file. This technically would mean we can delete all *txt files being produced by infretis while retaining all information.

Based on my benchmarks, this implementation slow down only minimally, and just increases cpu time a bit.

```
# 2000 steps without tar
bash runner.sh  60.68s user 25.72s system 72% cpu 1:59.77 total
# 2000 steps with tar
bash runner.sh  70.11s user 28.89s system 80% cpu 2:03.39 total

# 5000 steps without tar
bash runner.sh  144.51s user 58.09s system 67% cpu 5:01.03 total
# 5000 steps with tar
bash runner.sh  148.06s user 56.75s system 68% cpu 4:57.88 total
```

Still todo:
* test backward compability..
* adapt `inft wham -fener` to consider the tar file if exists.
* This may break some inft tools.. so maybe we can offer some simple plotting funcs that automatically take in the .tar file (or tar.gz)
* need to make it work with infinit
* What do we do if zip file becomes too large? i guess we can move zip, then infretis creates a new zip as it does not exist anymore

done:
* Do some `ctrl+C` crash tests to see if the tar file become corrupted. From premilinary ctrl +C, seems ok now

The tar file does not compress, so a simple thing is to do e.g. "gzip infretis_data.tar" -> "infretis_data.tar.gz" (80 MB -> 12 MB) from a 5000 step run.