### PR TITLE
Massively speed up trajectory reading.

### DIFF
--- a/infretis/classes/engines/gromacs.py
+++ b/infretis/classes/engines/gromacs.py
@@ -1319,11 +1319,14 @@ def read_coord(
             ``natoms`` rows and ``_DIM`` columns.
     """
     if double:
-        fmt = f"{endian}{natoms * _DIM}d"
+        dt = np.dtype("double")
     else:
-        fmt = f"{endian}{natoms * _DIM}f"
-    read = read_struct_buff(fileh, fmt)
-    mat = np.array(read)
+        dt = np.dtype("float32")
+    dt = dt.newbyteorder(endian)
+    try:
+        mat = np.fromfile(fileh, dtype=dt, count=natoms * _DIM)
+    except ValueError:
+        raise EOFError()
     mat.shape = (natoms, _DIM)
     return mat
 


### PR DESCRIPTION
This patch replaces the `struct.unpack`-based trajectory decoding with a call to `np.fromfile` directly.

This patch should be transparent to end users, aside from being faster.