### PR TITLE
Avoid calling flush() and fsync() on read-only files

### DIFF
--- a/infretis/classes/formatter.py
+++ b/infretis/classes/formatter.py
@@ -560,7 +560,11 @@ class FileIO(OutputBase):
 
     def flush(self) -> None:
         """Flush file buffers to file."""
-        if self.fileh is not None and not self.fileh.closed:
+        if (
+            self.fileh is not None
+            and not self.fileh.closed
+            and self.fileh.writable()
+        ):
             self.fileh.flush()
             os.fsync(self.fileh.fileno())
 


### PR DESCRIPTION
Calling fsync() on a read-only file handle raises an OSError on Windows, and it just silently does nothing on other platforms so it is entirely pointless anyway.