### PR TITLE
Maxlength fixes

### DIFF
--- a/infretis/classes/engines/ams.py
+++ b/infretis/classes/engines/ams.py
@@ -610,7 +610,7 @@ class AMSEngine(EngineBase):  # , metaclass=Singleton):
             }
 
             phase_point = self.snapshot_to_system(system, snapshot)
-            status, success, stop, _ = self.add_to_path(
+            status, success, stop, = self.add_to_path(
                 path, phase_point, left, right
             )
 

--- a/infretis/classes/engines/ams.py
+++ b/infretis/classes/engines/ams.py
@@ -610,9 +610,11 @@ class AMSEngine(EngineBase):  # , metaclass=Singleton):
             }
 
             phase_point = self.snapshot_to_system(system, snapshot)
-            status, success, stop, = self.add_to_path(
-                path, phase_point, left, right
-            )
+            (
+                status,
+                success,
+                stop,
+            ) = self.add_to_path(path, phase_point, left, right)
 
             kin_enes.append(
                 self.states[traj_file][i].get_kineticenergy(unit=self.ene_unit)

--- a/infretis/classes/engines/ase_engine.py
+++ b/infretis/classes/engines/ase_engine.py
@@ -193,7 +193,7 @@ class ASEEngine(EngineBase):
                     "vel_rev": reverse,
                 }
                 phase_point = self.snapshot_to_system(system, snapshot)
-                status, success, stop, add = self.add_to_path(
+                status, success, stop = self.add_to_path(
                     path, phase_point, left, right
                 )
 

--- a/infretis/classes/engines/cp2k.py
+++ b/infretis/classes/engines/cp2k.py
@@ -896,7 +896,7 @@ class CP2KEngine(EngineBase):
                             "vel_rev": reverse,
                         }
                         phase_point = self.snapshot_to_system(system, snapshot)
-                        status, success, stop, add = self.add_to_path(
+                        status, success, stop = self.add_to_path(
                             path, phase_point, left, right
                         )
                         if stop:

--- a/infretis/classes/engines/enginebase.py
+++ b/infretis/classes/engines/enginebase.py
@@ -93,14 +93,7 @@ class EngineBase(metaclass=ABCMeta):
         status = "Running propagate..."
         success = False
         stop = False
-        add = path.append(phase_point)
-        if not add:
-            if path.length >= path.maxlen:
-                status = "Max. path length exceeded"
-            else:  # pragma: no cover
-                status = "Could not add for unknown reason"
-            success = False
-            stop = True
+        path.append(phase_point)
         if path.phasepoints[-1].order[0] < left:
             status = "Crossed left interface!"
             success = True
@@ -109,11 +102,12 @@ class EngineBase(metaclass=ABCMeta):
             status = "Crossed right interface!"
             success = True
             stop = True
-        if path.length == path.maxlen:
-            status = "Max. path length exceeded!"
+        # check this last in case of crossing on the last step
+        elif path.length >= path.maxlen:
+            status = "Max. path length exceeded"
             success = False
             stop = True
-        return status, success, stop, add
+        return status, success, stop
 
     @abstractmethod
     def modify_velocities(

--- a/infretis/classes/engines/enginebase.py
+++ b/infretis/classes/engines/enginebase.py
@@ -78,7 +78,7 @@ class EngineBase(metaclass=ABCMeta):
     @staticmethod
     def add_to_path(
         path: InfPath, phase_point: System, left: float, right: float
-    ) -> Tuple[str, bool, bool, bool]:
+    ) -> Tuple[str, bool, bool]:
         """Add a phase point and perform some checks.
 
         This method is intended to be used by the propagate methods

--- a/infretis/classes/engines/enginebase.py
+++ b/infretis/classes/engines/enginebase.py
@@ -577,52 +577,6 @@ class EngineBase(metaclass=ABCMeta):
         for i in files:
             self._removefile(os.path.join(dirname, i))
 
-    def __eq__(self, other) -> bool:
-        """Check if two engines are equal."""
-        if self.__class__ != other.__class__:
-            logger.debug("%s and %s.__class__ differ", self, other)
-            return False
-
-        if set(self.__dict__) != set(other.__dict__):
-            logger.debug("%s and %s.__dict__ differ", self, other)
-            return False
-
-        for i in ["description", "_exe_dir", "timestep"]:
-            if hasattr(self, i):
-                if getattr(self, i) != getattr(other, i):
-                    logger.debug(
-                        "%s for %s and %s, attributes are %s and %s",
-                        i,
-                        self,
-                        other,
-                        getattr(self, i),
-                        getattr(other, i),
-                    )
-                    return False
-
-        if hasattr(self, "rgen"):
-            # pylint: disable=no-member
-            if self.rgen.__class__ != other.rgen.__class__ or set(
-                self.rgen.__dict__
-            ) != set(other.rgen.__dict__):
-                logger.debug("rgen class differs")
-                return False
-
-            # pylint: disable=no-member
-            for att1, att2 in zip(self.rgen.__dict__, other.rgen.__dict__):
-                # pylint: disable=no-member
-                if self.rgen.__dict__[att1] != other.rgen.__dict__[att2]:
-                    logger.debug(
-                        "rgen class attribute %s and %s differs", att1, att2
-                    )
-                    return False
-
-        return True
-
-    def __ne__(self, other) -> bool:
-        """Check if two engines are not equal."""
-        return not self == other
-
     def __str__(self) -> str:
         """Return the string description of the integrator."""
         return self.description

--- a/infretis/classes/engines/gromacs.py
+++ b/infretis/classes/engines/gromacs.py
@@ -529,7 +529,7 @@ class GromacsEngine(EngineBase):
                     "vel_rev": reverse,
                 }
                 phase_point = self.snapshot_to_system(system, snapshot)
-                status, success, stop, _ = self.add_to_path(
+                status, success, stop = self.add_to_path(
                     path, phase_point, left, right
                 )
                 if stop:

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -57,10 +57,8 @@ def write_lammpstrj(
     filemode = "a" if append else "w"
     box_header = "xy xz yz " if triclinic else ""
     with open(outfile, filemode) as writefile:
-        to_write = (
-            f"ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n{pos.shape[0]}\n\
-ITEM: BOX BOUNDS {box_header}pp pp pp\n" ""
-        )
+        to_write = f"ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n\
+{pos.shape[0]}\nITEM: BOX BOUNDS {box_header}pp pp pp\n"
 
         if box is not None:
             for box_vector in box:
@@ -256,8 +254,10 @@ def get_atom_masses(lammps_data: Union[str, Path], atom_style) -> np.ndarray:
 
     # if we did not find all of the information
     if n_atoms == 0 or n_atom_types == 0:
-        raise ValueError(f"Could not read atom masses from {lammps_data}. \
-                         Found {n_atoms} atoms and {n_atom_types} atom_types.")
+        raise ValueError(
+            f"Could not read atom masses from {lammps_data}. \
+                         Found {n_atoms} atoms and {n_atom_types} atom_types."
+        )
 
     if np.shape(atoms)[0] == 0 or np.any(np.isnan(atoms)):
         raise ValueError(f"Could not read 'Atoms' from {lammps_data}")

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -254,10 +254,8 @@ def get_atom_masses(lammps_data: Union[str, Path], atom_style) -> np.ndarray:
 
     # if we did not find all of the information
     if n_atoms == 0 or n_atom_types == 0:
-        raise ValueError(
-            f"Could not read atom masses from {lammps_data}. \
-                         Found {n_atoms} atoms and {n_atom_types} atom_types."
-        )
+        raise ValueError(f"Could not read atom masses from {lammps_data}. \
+                         Found {n_atoms} atoms and {n_atom_types} atom_types.")
 
     if np.shape(atoms)[0] == 0 or np.any(np.isnan(atoms)):
         raise ValueError(f"Could not read 'Atoms' from {lammps_data}")

--- a/infretis/classes/engines/lammps.py
+++ b/infretis/classes/engines/lammps.py
@@ -557,7 +557,7 @@ class LAMMPSEngine(EngineBase):
                             "vel_rev": reverse,
                         }
                         phase_point = self.snapshot_to_system(system, snapshot)
-                        status, success, stop, add = self.add_to_path(
+                        status, success, stop = self.add_to_path(
                             path, phase_point, left, right
                         )
                         if stop:

--- a/infretis/classes/engines/turtlemdengine.py
+++ b/infretis/classes/engines/turtlemdengine.py
@@ -272,7 +272,7 @@ class TurtleMDEngine(EngineBase):
                     "vel_rev": reverse,
                 }
                 phase_point = self.snapshot_to_system(system, snapshot)
-                status, success, stop, add = self.add_to_path(
+                status, success, stop = self.add_to_path(
                     path, phase_point, left, right
                 )
 

--- a/infretis/classes/path.py
+++ b/infretis/classes/path.py
@@ -156,11 +156,7 @@ class Path:
 
     def append(self, phasepoint: System) -> bool:
         """Append a new phase point to the path."""
-        if self.maxlen is None or self.length < self.maxlen:
-            self.phasepoints.append(phasepoint)
-            return True
-        logger.debug("Max length exceeded. Could not append to path.")
-        return False
+        self.phasepoints.append(phasepoint)
 
     def get_move(self) -> Optional[str]:
         """Return the move used to generate the path."""
@@ -192,12 +188,7 @@ class Path:
             The updated path object (self).
         """
         for phasepoint in other.phasepoints:
-            app = self.append(phasepoint.copy())
-            if not app:
-                logger.warning(
-                    "Truncated path at %d while adding paths", self.length
-                )
-                return self
+            self.append(phasepoint.copy())
         return self
 
     def copy(self) -> Path:
@@ -208,7 +199,6 @@ class Path:
         new_path.status = self.status
         new_path.time_origin = self.time_origin
         new_path.generated = self.generated
-        new_path.maxlen = self.maxlen
         new_path.path_number = self.path_number
         new_path.weights = self.weights
         return new_path
@@ -391,22 +381,13 @@ def paste_paths(
     time_origin = path_back.time_origin - path_back.length + 1
     new_path = path_back.empty_path(maxlen=maxlen, time_origin=time_origin)
     for phasepoint in reversed(path_back.phasepoints):
-        app = new_path.append(phasepoint)
-        if not app:
-            msg = "Truncated while pasting backwards at: {}"
-            msg = msg.format(new_path.length)
-            logger.warning(msg)
-            return new_path
+        new_path.append(phasepoint)
     first = True
     for phasepoint in path_forw.phasepoints:
         if first and overlap:
             first = False
             continue
-        app = new_path.append(phasepoint)
-        if not app:
-            msg = f"Truncated path at: {new_path.length}"
-            logger.warning(msg)
-            return new_path
+        new_path.append(phasepoint)
     return new_path
 
 

--- a/infretis/classes/path.py
+++ b/infretis/classes/path.py
@@ -154,7 +154,7 @@ class Path:
         logger.debug(f"Selected point with orderp {order}")
         return self.phasepoints[idx], idx
 
-    def append(self, phasepoint: System) -> bool:
+    def append(self, phasepoint: System) -> None:
         """Append a new phase point to the path."""
         self.phasepoints.append(phasepoint)
 

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -588,9 +588,11 @@ class REPEX_state:
         # edge case that negative probs exist: set to zero
         if np.sum(out < 0) > 0:
             out[out < 0] = 0
-            logger.info(f"Found {int(np.sum(out<0))} precision \
+            logger.info(
+                f"Found {int(np.sum(out<0))} precision \
                 errors in the P-matrix, setting negative \
-                elements to 0. min: {np.min(out):.3e}")
+                elements to 0. min: {np.min(out):.3e}"
+            )
 
         # reinsert zeroes for the locked ensembles
         final_out_rows = np.insert(out, insert_list, 0, axis=0)

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -588,11 +588,9 @@ class REPEX_state:
         # edge case that negative probs exist: set to zero
         if np.sum(out < 0) > 0:
             out[out < 0] = 0
-            logger.info(
-                f"Found {int(np.sum(out<0))} precision \
+            logger.info(f"Found {int(np.sum(out<0))} precision \
                 errors in the P-matrix, setting negative \
-                elements to 0. min: {np.min(out):.3e}"
-            )
+                elements to 0. min: {np.min(out):.3e}")
 
         # reinsert zeroes for the locked ensembles
         final_out_rows = np.insert(out, insert_list, 0, axis=0)

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -628,8 +628,8 @@ def extender(
 
     # Extender
     if interfaces[0] <= sh_pt.order[0] < interfaces[-1]:
-        # subtract source_seg length in maxlength, subtract 1 for forward extension
-        # add 2 for the overlap with source_seg at start and end
+        # maxlen: subtract source_seg length, subtract 1 for forward extension
+        # and add 2 for the overlap with source_seg at start and end
         back_segment = source_seg.empty_path(
             maxlen=ens_set["tis_set"]["maxlength"] - source_seg.length + 1
         )

--- a/infretis/core/tis.py
+++ b/infretis/core/tis.py
@@ -628,13 +628,15 @@ def extender(
 
     # Extender
     if interfaces[0] <= sh_pt.order[0] < interfaces[-1]:
+        # subtract source_seg length in maxlength, subtract 1 for forward extension
+        # add 2 for the overlap with source_seg at start and end
         back_segment = source_seg.empty_path(
-            maxlen=ens_set["tis_set"]["maxlength"]
+            maxlen=ens_set["tis_set"]["maxlength"] - source_seg.length + 1
         )
         logger.debug("Trying to extend backwards")
         source_seg_copy = source_seg.copy()
 
-        shoot_backwards(
+        success = shoot_backwards(
             back_segment, source_seg_copy, sh_pt, ens_set, engine, start_cond
         )
         trial_path = paste_paths(
@@ -643,23 +645,29 @@ def extender(
             overlap=True,
             maxlen=ens_set["tis_set"]["maxlength"],
         )
+        # backwards extension failed
+        if not success:
+            trial_path.status = "BTX"
+            return False, trial_path, trial_path.status
     else:
         trial_path = source_seg.copy()
 
     sh_pt = trial_path.phasepoints[-1].copy()
     if interfaces[0] <= sh_pt.order[0] < interfaces[-1]:
+        # subtract source_seg length, add 1 for overlap with source_seg
         forth_segment = source_seg.empty_path(
-            maxlen=ens_set["tis_set"]["maxlength"]
+            maxlen=ens_set["tis_set"]["maxlength"] - trial_path.length + 1
         )
-        engine.propagate(forth_segment, ens_set, sh_pt)
+        success, status = engine.propagate(forth_segment, ens_set, sh_pt)
 
         trial_path.phasepoints = (
             trial_path.phasepoints[:-1] + forth_segment.phasepoints
         )
+        # forward extensions faile
+        if not success:
+            trial_path.status = "FTX"
+            return False, trial_path, trial_path.status
 
-    if trial_path.length >= ens_set["tis_set"]["maxlength"]:
-        trial_path.status = "FTX"  # exceeds "memory".
-        return False, trial_path, trial_path.status
     trial_path.status = "ACC"
     return True, trial_path, trial_path.status
 
@@ -884,7 +892,9 @@ def retis_swap_zero(
     path_tmp = path_old1.empty_path(maxlen=maxlen1 - 1)
     if allowed:
         logger.info("Propagating for [0^-]")
-        engine0.propagate(path_tmp, ens_set0, shpt_copy, reverse=True)
+        success, status = engine0.propagate(
+            path_tmp, ens_set0, shpt_copy, reverse=True
+        )
     else:
         logger.info("Not propagating for [0^-]")
         path_tmp.append(shpt_copy)
@@ -901,7 +911,7 @@ def retis_swap_zero(
     logger.info("Point is %s", phase_point.order)
     engine1.dump_phasepoint(phase_point, "second")
     path0.append(phase_point)
-    if path0.length == maxlen0:
+    if path0.length >= maxlen0:
         path0.status = "BTX"
     elif path0.length < 3:
         path0.status = "BTS"
@@ -912,6 +922,9 @@ def retis_swap_zero(
         path0.status = "0-L"
     else:
         path0.status = "ACC"
+    # if propagation did not succeeed for some reason, reject the swap
+    if not success:
+        return False, [path0, path_old0], path0.status
 
     # 2. Generate path for [0^+] from [0^-]:
     logger.info("Creating path for [0^+] from [0^-]")
@@ -930,7 +943,9 @@ def retis_swap_zero(
         logger.info("Initial point is %s", system.order)
         # nsembles[1]['system'] = system
         logger.info("Propagating for [0^+]")
-        engine1.propagate(path_tmp, ens_set1, system, reverse=False)
+        success, status = engine1.propagate(
+            path_tmp, ens_set1, system, reverse=False
+        )
         # Ok, now we need to just add the SECOND LAST point from [0^-] as
         # the first point for the path:
         path1 = path_tmp.empty_path(maxlen=maxlen1)
@@ -961,6 +976,8 @@ def retis_swap_zero(
     else:
         path1.status = "ACC"
     logger.info("Done with swap zero!")
+    if not success:
+        return False, [path0, path1], path1.status
 
     # Final checks:
     accept = path0.status == "ACC" and path1.status == "ACC"


### PR DESCRIPTION
I wanted to test what happens when the maximum allowed path length is `maxlength`, but this gave some unexpected behavior.

This PR should fix that and resolves #208. 

In addition, this allows for earlier rejections when `maxlength` is hit somewhere. Previously, we would complete a path that could never be valid, since it did not cross the interfaces (because it hit `maxlength`). This happened in the `retis_swap_zero()` and `extender()` functions.
