### PR TITLE
Remove duplicated _GROMACS_MAGIC = 1993

### DIFF
--- a/infretis/classes/engines/gromacs.py
+++ b/infretis/classes/engines/gromacs.py
@@ -38,7 +38,6 @@ _GROMACS_MAGIC = 1993
 _G96_FMT = "{0:}{1:15.9f}{2:15.9f}{3:15.9f}\n"
 _G96_BOX_FMT = "{:15.9f}" * 9 + "\n"
 _G96_BOX_FMT_3 = "{:15.9f}" * 3 + "\n"
-_GROMACS_MAGIC = 1993
 _DIM = 3
 _TRR_VERSION = "GMX_trn_file"
 _SIZE_FLOAT = struct.calcsize("f")


### PR DESCRIPTION
The variable `_GROMACS_MAGIC = 1993` was defined twice in gromacs.py. This will remove one of them.