### PR TITLE
Enable variable ensemble picking scheme for infinit and misc fixes

### DIFF
--- a/infretis/classes/engines/gromacs.py
+++ b/infretis/classes/engines/gromacs.py
@@ -38,7 +38,6 @@ _GROMACS_MAGIC = 1993
 _G96_FMT = "{0:}{1:15.9f}{2:15.9f}{3:15.9f}\n"
 _G96_BOX_FMT = "{:15.9f}" * 9 + "\n"
 _G96_BOX_FMT_3 = "{:15.9f}" * 3 + "\n"
-_GROMACS_MAGIC = 1993
 _DIM = 3
 _TRR_VERSION = "GMX_trn_file"
 _SIZE_FLOAT = struct.calcsize("f")

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -169,7 +169,7 @@ class REPEX_state:
         prob = self.prob.astype("float64")
         if self.pick_scheme > 0:
             # Pick ensemble based on weight,
-            valid_idx = np.where(1. - self._locks)[0]
+            valid_idx = np.where(1.0 - self._locks)[0]
             ens_weights = np.zeros(self.n)
             ens_weights[valid_idx] = np.arange(1, len(valid_idx) + 1)
             prob *= ens_weights**self.pick_scheme
@@ -824,8 +824,10 @@ class REPEX_state:
     def print_start(self):
         """Print start."""
         if self.pick_scheme > 0:
-            logger.info(f"ensemble selection scheme: {self.pick_scheme}" +
-                         " should only be used with Inf-init")
+            logger.info(
+                f"ensemble selection scheme: {self.pick_scheme}"
+                + " should only be used with Inf-init"
+            )
         logger.info("stored ensemble paths:")
         ens_num = self.live_paths()
         logger.info(

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -80,8 +80,8 @@ class REPEX_state:
         self._last_prob = None
         self._random_count = 0
         self._trajs = [""] * n
-        self.zeroswap = config["simulation"].get("zeroswap", 0.5)
-        self.pick_scheme = config["simulation"].get("pick_scheme", 0)
+        self.zeroswap = config["simulation"]["zeroswap"]
+        self.pick_scheme = config["simulation"]["pick_scheme"]
 
         # detect any locked ens-path pairs exist pre start
         self.locked0 = list(self.config["current"].get("locked", []))
@@ -951,7 +951,7 @@ class REPEX_state:
                 }
                 traj_num += 1
                 if (
-                    self.config["output"].get("delete_old", False)
+                    self.config["output"]["delete_old"]
                     and pn_old > self.n - 2
                 ):
                     if len(self.pn_olds) > self.n - 2:
@@ -972,7 +972,7 @@ class REPEX_state:
                             for adress in del_dic["adress"]:
                                 os.remove(adress)
                         # delete txt files
-                        if self.config["output"].get("delete_old_all", False):
+                        if self.config["output"]["delete_old_all"]:
                             for txt in ("order.txt", "traj.txt", "energy.txt"):
                                 txt_adress = os.path.join(
                                     load_dir, pn_old_del, txt

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -80,7 +80,8 @@ class REPEX_state:
         self._last_prob = None
         self._random_count = 0
         self._trajs = [""] * n
-        self.zeroswap = 0.5
+        self.zeroswap = config["simulation"].get("zeroswap", 0.5)
+        self.pick_scheme = config["simulation"].get("pick_scheme", 0)
 
         # detect any locked ens-path pairs exist pre start
         self.locked0 = list(self.config["current"].get("locked", []))
@@ -165,9 +166,18 @@ class REPEX_state:
 
     def pick(self):
         """Pick path and ens."""
-        prob = self.prob.astype("float64").flatten()
+        prob = self.prob.astype("float64")
+        if self.pick_scheme > 0:
+            # Pick ensemble based on weight,
+            valid_idx = np.where(1. - self._locks)[0]
+            ens_weights = np.zeros(self.n)
+            ens_weights[valid_idx] = np.arange(1, len(valid_idx) + 1)
+            prob *= ens_weights**self.pick_scheme
+
+        prob = prob.flatten()
         p = self.rgen.choice(self.n**2, p=np.nan_to_num(prob / np.sum(prob)))
         traj, ens = np.divmod(p, self.n)
+
         self.swap(traj, ens)
         self.lock(ens)
         traj = self._trajs[ens]
@@ -797,9 +807,10 @@ class REPEX_state:
         status = md_items["status"]
         simtime = md_items["md_end"] - md_items["md_start"]
         subcycles = md_items["subcycles"]
+        arrow = "=)" if status == "ACC" else "=("
         logger.info(
             f"shooted {' '.join(moves)} in ensembles: {ens_nums}"
-            f" with paths: {pnum_old} -> {pnum_new}"
+            f" with paths: {pnum_old} {arrow} {pnum_new}"
         )
         logger.info(
             "with status:" f" {status} len: {trial_lens} op: {trial_ops} and"
@@ -812,6 +823,9 @@ class REPEX_state:
 
     def print_start(self):
         """Print start."""
+        if self.pick_scheme > 0:
+            logger.info(f"ensemble selection scheme: {self.pick_scheme}" +
+                         " should only be used with Inf-init")
         logger.info("stored ensemble paths:")
         ens_num = self.live_paths()
         logger.info(

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -950,10 +950,7 @@ class REPEX_state:
                     "ens_save_idx": ens_save_idx,
                 }
                 traj_num += 1
-                if (
-                    self.config["output"]["delete_old"]
-                    and pn_old > self.n - 2
-                ):
+                if self.config["output"]["delete_old"] and pn_old > self.n - 2:
                     if len(self.pn_olds) > self.n - 2:
                         pn_old_del, del_dic = next(iter(self.pn_olds.items()))
                         load_dir = self.config["simulation"]["load_dir"]

--- a/infretis/classes/repex.py
+++ b/infretis/classes/repex.py
@@ -168,7 +168,8 @@ class REPEX_state:
         """Pick path and ens."""
         prob = self.prob.astype("float64")
         if self.pick_scheme > 0:
-            # Pick ensemble based on weight,
+            # Pick ensemble based on weight, primarily only necessary
+            # for inf-init simulations.
             valid_idx = np.where(1.0 - self._locks)[0]
             ens_weights = np.zeros(self.n)
             ens_weights[valid_idx] = np.arange(1, len(valid_idx) + 1)

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -150,16 +150,31 @@ def setup_config(
             ens_engs.append(["engine"])
         config["simulation"]["ensemble_engines"] = ens_engs
 
+
     # set all keywords only once, so they appear in restart.toml
     # and we can avoid the .get() in other parts
     if "seed" not in config["simulation"].keys():
         config["simulation"]["seed"] = 0
 
-    # [output]
-    keep_maxop_trajs = config["output"].get("keep_maxop_trajs", False)
-    config["output"]["keep_maxop_trajs"] = keep_maxop_trajs
-    delete_old = config["output"].get("delete_old", False)
-    delete_old_all = config["output"].get("delete_old_all", False)
+    # [simulation] defaults
+    config["simulation"].setdefault("load_dir", "load")
+    config["simulation"].setdefault("zeroswap", 0.5)
+    config["simulation"].setdefault("pick_scheme", 0)
+
+    # [simulation.tis_set] defaults
+    config["simulation"]["tis_set"].setdefault("quantis", False)
+    config["simulation"]["tis_set"].setdefault("lambda_minus_one", False)
+    config["simulation"]["tis_set"].setdefault("accept_all", False)
+
+    # [output] defaults
+    config["output"].setdefault("keep_maxop_trajs", False)
+    config["output"].setdefault("delete_old", False)
+    config["output"].setdefault("delete_old_all", False)
+
+    # validation for output settings
+    keep_maxop_trajs = config["output"]["keep_maxop_trajs"]
+    delete_old = config["output"]["delete_old"]
+    delete_old_all = config["output"]["delete_old_all"]
     if not delete_old and keep_maxop_trajs:
         raise TOMLConfigError("keep_maxop_trajs=True requires delete_old=True")
     if delete_old_all and keep_maxop_trajs:
@@ -169,16 +184,10 @@ def setup_config(
         )
         raise TOMLConfigError(msg)
 
-    quantis = config["simulation"]["tis_set"].get("quantis", False)
-    config["simulation"]["tis_set"]["quantis"] = quantis
-
-    l_1 = config["simulation"]["tis_set"].get("lambda_minus_one", False)
-    config["simulation"]["tis_set"]["lambda_minus_one"] = l_1
-
+    # handle quantis configuration
+    quantis = config["simulation"]["tis_set"]["quantis"]
     if quantis and not has_ens_engs:
         config["simulation"]["ensemble_engines"][0] = ["engine0"]
-    accept_all = config["simulation"]["tis_set"].get("accept_all", False)
-    config["simulation"]["tis_set"]["accept_all"] = accept_all
 
     check_config(config)
 
@@ -196,10 +205,8 @@ def check_config(config: dict) -> None:
     n_workers = config["runner"]["workers"]
     sh_moves = config["simulation"]["shooting_moves"]
     n_sh_moves = len(sh_moves)
+    lambda_minus_one = config["simulation"]["tis_set"]["lambda_minus_one"]
     intf_cap = config["simulation"]["tis_set"].get("interface_cap", False)
-    lambda_minus_one = config["simulation"]["tis_set"].get(
-        "lambda_minus_one", False
-    )
 
     if lambda_minus_one is not False and lambda_minus_one >= intf[0]:
         raise TOMLConfigError(

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -165,6 +165,8 @@ def setup_config(
     config["simulation"]["tis_set"].setdefault("quantis", False)
     config["simulation"]["tis_set"].setdefault("lambda_minus_one", False)
     config["simulation"]["tis_set"].setdefault("accept_all", False)
+    # we do not set default interface_cap here, it defaults to
+    # interfaces[-1] in wf already.
 
     # [output] defaults
     config["output"].setdefault("keep_maxop_trajs", False)

--- a/infretis/setup.py
+++ b/infretis/setup.py
@@ -150,7 +150,6 @@ def setup_config(
             ens_engs.append(["engine"])
         config["simulation"]["ensemble_engines"] = ens_engs
 
-
     # set all keywords only once, so they appear in restart.toml
     # and we can avoid the .get() in other parts
     if "seed" not in config["simulation"].keys():

--- a/test/permanents/test_permanents.py
+++ b/test/permanents/test_permanents.py
@@ -76,7 +76,8 @@ def test_matrix1():
         {
             "current": {"size": 1, "cstep": 0},
             "runner": {"workers": 1},
-            "simulation": {"seed": 0, "steps": 10},
+            "simulation": {"seed": 0, "steps":10,
+                           "zeroswap": 0.5, "pick_scheme": 0},
         }
     )
     p_matrix = state.permanent_prob(W_MATRIX1)
@@ -91,7 +92,8 @@ def test_matrix2():
         {
             "current": {"size": 1, "cstep": 0},
             "runner": {"workers": 1},
-            "simulation": {"seed": 0, "steps": 10},
+            "simulation": {"seed": 0, "steps":10,
+                           "zeroswap": 0.5, "pick_scheme": 0},
         }
     )
     p_matrix = state.permanent_prob(W_MATRIX2)
@@ -110,7 +112,8 @@ def test_matrix3(caplog):
         {
             "current": {"size": 1, "cstep": 0},
             "runner": {"workers": 1},
-            "simulation": {"seed": 0, "steps": 10},
+            "simulation": {"seed": 0, "steps":10,
+                           "zeroswap": 0.5, "pick_scheme": 0},
         },
         minus=True
     )

--- a/test/repex/test_repex.py
+++ b/test/repex/test_repex.py
@@ -11,7 +11,8 @@ def test_rgen_io(tmp_path: PosixPath) -> None:
         {
             "current": {"size": 1, "cstep": 0},
             "runner": {"workers": 1},
-            "simulation": {"seed": 0, "steps":10},
+            "simulation": {"seed": 0, "steps":10,
+                           "zeroswap": 0.5, "pick_scheme": 0},
         }
     )
     folder = tmp_path / "temp"

--- a/test/simulations/data/10steps_wf/restart.toml
+++ b/test/simulations/data/10steps_wf/restart.toml
@@ -61,6 +61,8 @@ ensemble_engines = [
         "engine",
     ],
 ]
+zeroswap = 0.5
+pick_scheme = 0
 
 [simulation.tis_set]
 maxlength = 2000

--- a/test/simulations/data/20steps_wf/restart.toml
+++ b/test/simulations/data/20steps_wf/restart.toml
@@ -61,6 +61,8 @@ ensemble_engines = [
         "engine",
     ],
 ]
+zeroswap = 0.5
+pick_scheme = 0
 
 [simulation.tis_set]
 maxlength = 2000

--- a/test/simulations/data/30steps_wf/restart.toml
+++ b/test/simulations/data/30steps_wf/restart.toml
@@ -61,6 +61,8 @@ ensemble_engines = [
         "engine",
     ],
 ]
+zeroswap = 0.5
+pick_scheme = 0
 
 [simulation.tis_set]
 maxlength = 2000


### PR DESCRIPTION
Inf-init becomes more efficient when the higher ensembles have a higher probability to be picked, where the default is uniform (any random ensemble). 

This PR allows a way to have a linear increase in ensemble being picked, e.g. if we have 3 ensembles 1, 2, 3, then the pick_scheme = 1, we have probabilities (1, 2, 3)/6. For pick_scheme = 2 we have quadratic, e.g. (1, 4, 9)/14, and for pick_scheme = 3 we have cubic, e.g. (1, 8, 27)/36 and so on, 
<img width="640" height="480" alt="perf" src="https://github.com/user-attachments/assets/fc910683-dc7f-4b4a-b30f-5126a25b8fb8" />

* now allow to adjust zero swap probability in toml
* Maybe fix the double gromacs line if i can pass the pipeline (https://github.com/infretis/infretis/pull/210)
* Change arrows to smileys https://github.com/infretis/infretis/issues/213
* I decided for now to not add any new tests, but rather makes infretis print out all default settings, solves issue https://github.com/infretis/infretis/issues/215
